### PR TITLE
fix: stitches injection order

### DIFF
--- a/.changeset/afraid-worms-own.md
+++ b/.changeset/afraid-worms-own.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix css injection order creating an issue with buttons that have background color.

--- a/sigle/src/pages/_document.tsx
+++ b/sigle/src/pages/_document.tsx
@@ -29,6 +29,10 @@ export default class MyDocument extends Document {
           <>
             {initialProps.styles}
             {sheet.getStyleElement()}
+            <style
+              id="stitches"
+              dangerouslySetInnerHTML={{ __html: getCssText() }}
+            />
           </>
         ),
       };
@@ -61,10 +65,6 @@ export default class MyDocument extends Document {
           <meta name="msapplication-TileColor" content="#da532c" />
           <meta name="theme-color" content="#ffffff" />
           <link rel="manifest" href={`${sigleConfig.appUrl}/manifest.json`} />
-          <style
-            id="stitches"
-            dangerouslySetInnerHTML={{ __html: getCssText() }}
-          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
With this, we force stitches to be rendered last so we know the reset CSS defaults will not overwrite the stitches css