### PR TITLE
feat: improve cover image behavior new editor

### DIFF
--- a/.changeset/metal-oranges-trade.md
+++ b/.changeset/metal-oranges-trade.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': minor
+---
+
+Experimental editor: improve cover image behavior.

--- a/sigle/src/modules/editor/CoverImage.tsx
+++ b/sigle/src/modules/editor/CoverImage.tsx
@@ -7,8 +7,6 @@ import { resizeImage } from '../../utils/image';
 import { Story } from '../../types';
 import { storage } from '../../utils/blockstack';
 
-// TODO heading cover: HX should not have padding top
-
 const StyledImage = styled('img', {
   variants: {
     loading: {

--- a/sigle/src/modules/editor/CoverImage.tsx
+++ b/sigle/src/modules/editor/CoverImage.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useState } from 'react';
+import { CameraIcon, TrashIcon } from '@radix-ui/react-icons';
+import { useDropzone } from 'react-dropzone';
+import { styled } from '../../stitches.config';
+import { Box, Button, IconButton } from '../../ui';
+import { resizeImage } from '../../utils/image';
+import { Story } from '../../types';
+import { storage } from '../../utils/blockstack';
+
+const StyledImage = styled('img', {
+  variants: {
+    loading: {
+      true: {
+        opacity: 0.25,
+      },
+    },
+  },
+});
+
+interface CoverImageProps {
+  story: Story;
+  setStoryFile: (story: Story) => void;
+}
+
+export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
+  const [loadingSave, setLoadingSave] = useState(false);
+
+  const handleRemoveCoverImage = () => {
+    setStoryFile({ ...story, coverImage: undefined });
+  };
+
+  const onDrop = useCallback(async (acceptedFiles) => {
+    const file: File | undefined = acceptedFiles[0];
+    if (!file) return;
+    const [mime] = file.type.split('/');
+    if (mime !== 'image') return;
+
+    // We show a preview of  the image image as uploading can take a while...
+    const preview = URL.createObjectURL(file);
+    setLoadingSave(true);
+    setStoryFile({ ...story, coverImage: preview });
+
+    const blob = await resizeImage(file, { maxWidth: 2000 });
+    const now = new Date().getTime();
+    const name = `photos/${story.id}/${now}-${file.name}`;
+    const coverImageUrl = await storage.putFile(name, blob, {
+      encrypt: false,
+      contentType: blob.type,
+    });
+
+    setLoadingSave(false);
+    setStoryFile({ ...story, coverImage: coverImageUrl });
+  }, []);
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop,
+    accept: 'image/jpeg,image/png',
+  });
+
+  const coverImage = story.coverImage;
+
+  return (
+    <>
+      {!coverImage ? (
+        <Box css={{ mt: '$5' }} {...getRootProps()}>
+          <input {...getInputProps()} />
+          <Button
+            variant="ghost"
+            css={{ color: '$gray9', gap: '$1' }}
+            type="submit"
+          >
+            <CameraIcon />
+            Add cover image
+          </Button>
+        </Box>
+      ) : (
+        <Box
+          css={{
+            margin: '2em auto',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+          className="not-prose"
+        >
+          <Box css={{ position: 'relative' }}>
+            <StyledImage src={coverImage} loading={loadingSave} />
+            <IconButton
+              css={{ position: 'absolute', top: '$2', right: '$2' }}
+              variant="solid"
+              title="Remove cover image"
+              onClick={handleRemoveCoverImage}
+            >
+              <TrashIcon />
+            </IconButton>
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/sigle/src/modules/editor/CoverImage.tsx
+++ b/sigle/src/modules/editor/CoverImage.tsx
@@ -7,6 +7,8 @@ import { resizeImage } from '../../utils/image';
 import { Story } from '../../types';
 import { storage } from '../../utils/blockstack';
 
+// TODO heading cover: HX should not have padding top
+
 const StyledImage = styled('img', {
   variants: {
     loading: {
@@ -56,11 +58,9 @@ export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
     accept: 'image/jpeg,image/png',
   });
 
-  const coverImage = story.coverImage;
-
   return (
     <>
-      {!coverImage ? (
+      {!story.coverImage ? (
         <Box css={{ mt: '$5' }} {...getRootProps()}>
           <input {...getInputProps()} />
           <Button
@@ -75,16 +75,27 @@ export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
       ) : (
         <Box
           css={{
-            margin: '2em auto',
+            margin: '$8 auto',
             display: 'flex',
             justifyContent: 'center',
           }}
           className="not-prose"
         >
-          <Box css={{ position: 'relative' }}>
-            <StyledImage src={coverImage} loading={loadingSave} />
+          <Box
+            css={{
+              position: 'relative',
+              marginLeft: '-$20',
+              marginRight: '-$20',
+            }}
+          >
+            <StyledImage src={story.coverImage} loading={loadingSave} />
             <IconButton
-              css={{ position: 'absolute', top: '$2', right: '$2' }}
+              css={{
+                position: 'absolute',
+                top: '$2',
+                right: '$2',
+                opacity: 0.7,
+              }}
               variant="solid"
               title="Remove cover image"
               onClick={handleRemoveCoverImage}

--- a/sigle/src/modules/editor/NewEditor.tsx
+++ b/sigle/src/modules/editor/NewEditor.tsx
@@ -31,7 +31,8 @@ const TitleInput = styled('input', {
 
 const EditorContainer = styled('div', {
   margin: '0 auto',
-  paddingTop: 60,
+  paddingTop: '$15',
+  paddingBottom: '$15',
 });
 
 interface NewEditorProps {

--- a/sigle/src/modules/editor/NewEditor.tsx
+++ b/sigle/src/modules/editor/NewEditor.tsx
@@ -4,10 +4,9 @@ import { toast } from 'react-toastify';
 import NProgress from 'nprogress';
 import * as Fathom from 'fathom-client';
 import posthog from 'posthog-js';
-import { CameraIcon } from '@radix-ui/react-icons';
 import { styled } from '../../stitches.config';
 import { Story } from '../../types';
-import { Box, Button, Container, Flex, Text } from '../../ui';
+import { Container, Text } from '../../ui';
 import { EditorHeader } from './EditorHeader';
 import { PublishDialog } from './PublishDialog';
 import { TipTapEditor } from './TipTapEditor';
@@ -17,6 +16,7 @@ import { Goals } from '../../utils/fathom';
 import { UnpublishDialog } from './UnpublishDialog';
 import { PublishedDialog } from './PublishedDialog';
 import { migrationStory } from '../../utils/migrations/story';
+import { CoverImage } from './CoverImage';
 
 const TitleInput = styled('input', {
   outline: 'transparent',
@@ -197,12 +197,8 @@ export const NewEditor = ({ story }: NewEditorProps) => {
           }}
           placeholder="Title"
         />
-        <Box css={{ mt: '$5' }}>
-          <Button variant="ghost" css={{ color: '$gray9', gap: '$1' }}>
-            <CameraIcon />
-            Add cover image
-          </Button>
-        </Box>
+        <CoverImage story={newStory} setStoryFile={setNewStory} />
+
         <TipTapEditor ref={editorRef} story={story} />
       </EditorContainer>
 

--- a/sigle/src/modules/editor/NewEditor.tsx
+++ b/sigle/src/modules/editor/NewEditor.tsx
@@ -4,9 +4,10 @@ import { toast } from 'react-toastify';
 import NProgress from 'nprogress';
 import * as Fathom from 'fathom-client';
 import posthog from 'posthog-js';
+import { CameraIcon } from '@radix-ui/react-icons';
 import { styled } from '../../stitches.config';
 import { Story } from '../../types';
-import { Container, Text } from '../../ui';
+import { Box, Button, Container, Flex, Text } from '../../ui';
 import { EditorHeader } from './EditorHeader';
 import { PublishDialog } from './PublishDialog';
 import { TipTapEditor } from './TipTapEditor';
@@ -196,6 +197,12 @@ export const NewEditor = ({ story }: NewEditorProps) => {
           }}
           placeholder="Title"
         />
+        <Box css={{ mt: '$5' }}>
+          <Button variant="ghost" css={{ color: '$gray9', gap: '$1' }}>
+            <CameraIcon />
+            Add cover image
+          </Button>
+        </Box>
         <TipTapEditor ref={editorRef} story={story} />
       </EditorContainer>
 

--- a/sigle/src/modules/editor/TipTapEditor.tsx
+++ b/sigle/src/modules/editor/TipTapEditor.tsx
@@ -43,7 +43,6 @@ const fadeInAnimation = keyframes({
 
 const StyledEditorContent = styled(EditorContent, {
   '& .ProseMirror': {
-    py: '$4',
     minHeight: 150,
   },
   '& .ProseMirror-focused': {

--- a/sigle/src/ui/IconButton.ts
+++ b/sigle/src/ui/IconButton.ts
@@ -16,6 +16,7 @@ export const IconButton = styled('button', {
     color: {
       gray: {
         color: '$gray11',
+        backgroundColor: '$gray3',
         '&:hover': {
           backgroundColor: '$gray4',
         },
@@ -24,9 +25,25 @@ export const IconButton = styled('button', {
         },
       },
     },
+    variant: {
+      solid: {},
+      ghost: {
+        backgroundColor: 'transparent',
+      },
+    },
   },
+  compoundVariants: [
+    {
+      color: 'gray',
+      variant: 'ghost',
+      css: {
+        backgroundColor: 'transparent',
+      },
+    },
+  ],
   defaultVariants: {
     size: 'md',
     color: 'gray',
+    variant: 'ghost',
   },
 });


### PR DESCRIPTION
You can now edit on the editor page directly the cover image (not in the settings). Only available on the new editor.