### PR TITLE
fix: word count showing on published story

### DIFF
--- a/.changeset/smart-lies-complain.md
+++ b/.changeset/smart-lies-complain.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix word count showing on published story page.

--- a/sigle/src/modules/editor/TipTapEditor.tsx
+++ b/sigle/src/modules/editor/TipTapEditor.tsx
@@ -200,7 +200,9 @@ export const TipTapEditor = forwardRef<
           textAlign: 'right',
         }}
       >
-        <Text size="sm">{editor?.storage.characterCount.words()} words</Text>
+        {editable && (
+          <Text size="sm">{editor?.storage.characterCount.words()} words</Text>
+        )}
       </Container>
     </>
   );


### PR DESCRIPTION
This pr fixes the word count being shown on a published story page.

Fixes #346 