### PR TITLE
refactor: migrate PoweredBy styles from styled components to stitches

### DIFF
--- a/.changeset/lovely-knives-tie.md
+++ b/.changeset/lovely-knives-tie.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Migrate styles from styled components to Stitches.

--- a/sigle/src/modules/publicStory/components/PoweredBy.tsx
+++ b/sigle/src/modules/publicStory/components/PoweredBy.tsx
@@ -1,19 +1,22 @@
-import styled from 'styled-components';
-import tw from 'twin.macro';
+import { styled } from '../../../stitches.config';
 
-const StyledPoweredBy = styled.div`
-  ${tw`flex justify-center mt-16`};
-  color: #c7c7c7;
+const StyledPoweredBy = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  mt: '$4',
+  color: '$gray8',
 
-  a {
-    ${tw`flex flex-col items-center`};
-  }
+  '& a': {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
 
-  img {
-    ${tw`mt-1`};
-    height: 25px;
-  }
-`;
+  '& img': {
+    mt: '$1',
+    height: 25,
+  },
+});
 
 export const PoweredBy = () => {
   return (


### PR DESCRIPTION
This pr migrates the styling of `Powered By` section from styled components to stitches.

Closes https://github.com/sigle/sigle/issues/348