### PR TITLE
chore: create first major release

### DIFF
--- a/.changeset/fair-falcons-kiss.md
+++ b/.changeset/fair-falcons-kiss.md
@@ -1,0 +1,6 @@
+---
+'@sigle/tailwind-style': major
+'@sigle/app': major
+---
+
+First major version to have concistent versionning after this release.


### PR DESCRIPTION
Let's mark the current version as 1.0.0 and follow consistent versioning from now on.