### PR TITLE
feat: underline links

### DIFF
--- a/.changeset/grumpy-swans-invite.md
+++ b/.changeset/grumpy-swans-invite.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Add underline to links when hovering.

--- a/sigle/src/modules/publicStory/PublicStory.tsx
+++ b/sigle/src/modules/publicStory/PublicStory.tsx
@@ -80,6 +80,13 @@ export const PublicStory = ({ story, settings }: PublicStoryProps) => {
           "& :where(a strong):not(:where([class~='not-prose'] *))": {
             color: safeSiteColor,
           },
+          '.ProseMirror': {
+            '& a': {
+              '&:hover': {
+                boxShadow: '0 1px 0 0 currentColor',
+              },
+            },
+          },
         }}
       >
         <Link href="/[username]" as={`/${username}`} passHref>


### PR DESCRIPTION
This pr updates links on the article page to be underlined when hovered. 

Resolves #398 