### PR TITLE
fix: underlined links outside of article

### DIFF
--- a/.changeset/eighty-ghosts-care.md
+++ b/.changeset/eighty-ghosts-care.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Remove underline on hover showing on links outside of the public story.

--- a/.changeset/proud-tigers-fail.md
+++ b/.changeset/proud-tigers-fail.md
@@ -2,4 +2,4 @@
 '@sigle/tailwind-style': patch
 ---
 
-Fix underline on links showing up outside of article.
+Fix double underline appearing on editor where a user manually adds an underline to a link.

--- a/.changeset/proud-tigers-fail.md
+++ b/.changeset/proud-tigers-fail.md
@@ -1,0 +1,5 @@
+---
+'@sigle/tailwind-style': patch
+---
+
+Fix underline on links showing up outside of article.

--- a/packages/tailwind-style/dist/tailwind.css
+++ b/packages/tailwind-style/dist/tailwind.css
@@ -846,7 +846,7 @@ Ensure the default browser behavior of the `hidden` attribute.
   color: var(--tw-prose-links);
 }
 
-.prose :where(a:hover):not(:where([class~='not-prose'] *)) {
+.prose :where(.ProseMirror):not(:where([class~='not-prose'] *)) a:hover {
   box-shadow: 0 1px 0 0 currentColor;
 }
 

--- a/packages/tailwind-style/dist/tailwind.css
+++ b/packages/tailwind-style/dist/tailwind.css
@@ -846,7 +846,7 @@ Ensure the default browser behavior of the `hidden` attribute.
   color: var(--tw-prose-links);
 }
 
-.prose :where(.ProseMirror):not(:where([class~='not-prose'] *)) a:hover {
+.prose :where(a:hover):not(:where([class~='not-prose'] *)) {
   box-shadow: 0 1px 0 0 currentColor;
 }
 

--- a/packages/tailwind-style/dist/tailwind.css
+++ b/packages/tailwind-style/dist/tailwind.css
@@ -850,6 +850,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   box-shadow: 0 1px 0 0 currentColor;
 }
 
+.prose :where(u):not(:where([class~='not-prose'] *)) {
+  text-decoration: none;
+  box-shadow: 0 1px 0 0 currentColor;
+}
+
 .dark .dark\:prose-invert {
   --tw-prose-body: var(--tw-prose-invert-body);
   --tw-prose-headings: var(--tw-prose-invert-headings);

--- a/packages/tailwind-style/tailwind.config.js
+++ b/packages/tailwind-style/tailwind.config.js
@@ -144,10 +144,8 @@ module.exports = {
             'a strong': {
               color: 'var(--tw-prose-links)',
             },
-            '.ProseMirror': {
-              'a:hover': {
-                boxShadow: '0 1px 0 0 currentColor',
-              },
+            'a:hover': {
+              boxShadow: '0 1px 0 0 currentColor',
             },
             u: {
               textDecoration: 'none',

--- a/packages/tailwind-style/tailwind.config.js
+++ b/packages/tailwind-style/tailwind.config.js
@@ -144,8 +144,10 @@ module.exports = {
             'a strong': {
               color: 'var(--tw-prose-links)',
             },
-            'a:hover': {
-              boxShadow: '0 1px 0 0 currentColor',
+            '.ProseMirror': {
+              'a:hover': {
+                boxShadow: '0 1px 0 0 currentColor',
+              },
             },
             img: {
               marginTop: false,

--- a/packages/tailwind-style/tailwind.config.js
+++ b/packages/tailwind-style/tailwind.config.js
@@ -149,6 +149,10 @@ module.exports = {
                 boxShadow: '0 1px 0 0 currentColor',
               },
             },
+            u: {
+              textDecoration: 'none',
+              boxShadow: '0 1px 0 0 currentColor',
+            },
             img: {
               marginTop: false,
               marginBottom: false,

--- a/sigle/src/modules/publicStory/PublicStory.tsx
+++ b/sigle/src/modules/publicStory/PublicStory.tsx
@@ -140,9 +140,14 @@ export const PublicStory = ({ story, settings }: PublicStoryProps) => {
           },
         }}
       >
-        <Flex justify="between" align="end" css={{ mb: '$7' }}>
+        <Flex
+          justify="between"
+          align="end"
+          css={{ mb: '$7' }}
+          className="not-prose"
+        >
           <Link href="/[username]" as={`/${username}`} passHref>
-            <a className="not-prose">
+            <a>
               <Text size="action">{siteName}</Text>
               <Text
                 size="action"

--- a/sigle/src/modules/publicStory/ShareButtons.tsx
+++ b/sigle/src/modules/publicStory/ShareButtons.tsx
@@ -58,6 +58,7 @@ export const ShareButtons = ({
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
+              className="not-prose"
               as="a"
               href={`https://twitter.com/intent/tweet?text=${title} by ${siteName}&url=${sigleConfig.appUrl}/${username}/${story.id}`}
               target="_blank"
@@ -73,6 +74,7 @@ export const ShareButtons = ({
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
+              className="not-prose"
               as="a"
               href={`https://www.facebook.com/sharer/sharer.php?u=${sigleConfig.appUrl}/${siteName}/${story.id}&quote=${title} by ${username}`}
               target="_blank"
@@ -88,6 +90,7 @@ export const ShareButtons = ({
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
+              className="not-prose"
               as="a"
               href={`https://www.linkedin.com/sharing/share-offsite/?url=${sigleConfig.appUrl}/${user?.username}/${story.id}`}
               target="_blank"

--- a/sigle/src/modules/publicStory/ShareButtons.tsx
+++ b/sigle/src/modules/publicStory/ShareButtons.tsx
@@ -53,12 +53,12 @@ export const ShareButtons = ({
         },
       }}
       gap="6"
+      className="not-prose"
     >
       <Flex gap="3">
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
-              className="not-prose"
               as="a"
               href={`https://twitter.com/intent/tweet?text=${title} by ${siteName}&url=${sigleConfig.appUrl}/${username}/${story.id}`}
               target="_blank"
@@ -74,7 +74,6 @@ export const ShareButtons = ({
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
-              className="not-prose"
               as="a"
               href={`https://www.facebook.com/sharer/sharer.php?u=${sigleConfig.appUrl}/${siteName}/${story.id}&quote=${title} by ${username}`}
               target="_blank"
@@ -90,7 +89,6 @@ export const ShareButtons = ({
         <Tooltip delayDuration={200}>
           <TooltipTrigger asChild>
             <Box
-              className="not-prose"
               as="a"
               href={`https://www.linkedin.com/sharing/share-offsite/?url=${sigleConfig.appUrl}/${user?.username}/${story.id}`}
               target="_blank"


### PR DESCRIPTION
This pr fixes the issue of underlined links outside of the article itself (Date, share icons). 

Questions/Concerns: 
- As Quentin mentioned, links are still underlined in the editor so if a user wants to manually underline using `Ctrl/Cmd + U` 2 underlines will appear. Do you have any ideas on how best to approach resolving this @pradel ?

Closes #426 