### PR TITLE
feat: use button for dropdown trigger

### DIFF
--- a/.changeset/tall-bats-retire.md
+++ b/.changeset/tall-bats-retire.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Use button component for header dropdown trigger.

--- a/sigle/src/modules/layout/components/AppHeader.tsx
+++ b/sigle/src/modules/layout/components/AppHeader.tsx
@@ -57,6 +57,7 @@ const StatusDot = styled('div', {
   width: '$2',
   height: '$2',
   borderRadius: '$round',
+  mr: '$2',
 });
 
 export const AppHeader = () => {
@@ -161,20 +162,10 @@ export const AppHeader = () => {
         {user ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Flex
-                tabIndex={0}
-                css={{
-                  cursor: 'pointer',
-                  p: '$3',
-                  br: '$1',
-                  '&:hover': { backgroundColor: '$gray4' },
-                }}
-                gap="2"
-                align="center"
-              >
+              <Button size="lg" variant="ghost">
                 <StatusDot />
                 <Text size="sm">{user.username}</Text>
-              </Flex>
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent sideOffset={8}>
               <DropdownMenuItem


### PR DESCRIPTION
This pr updates the dropdown (header) trigger to prefer using a button over the `Flex` element.