### PR TITLE
fix: dialog and settings text color on dark mode

### DIFF
--- a/.changeset/long-elephants-wink.md
+++ b/.changeset/long-elephants-wink.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix incorrect text colors on dark mode in dialog modal and settings page.

--- a/sigle/src/components/Form.ts
+++ b/sigle/src/components/Form.ts
@@ -6,7 +6,7 @@ export const FormRow = styled.div`
 `;
 
 export const FormLabel = styled.label`
-  ${tw`w-full block tracking-wide font-bold text-black mb-2`};
+  ${tw`w-full block tracking-wide font-bold mb-2`};
 `;
 
 export const FormInput = styled.input`

--- a/sigle/src/ui/Dialog.tsx
+++ b/sigle/src/ui/Dialog.tsx
@@ -41,7 +41,8 @@ const contentShow = keyframes({
 });
 
 const StyledContent = styled(DialogPrimitive.Content, {
-  backgroundColor: 'white',
+  backgroundColor: '$gray1',
+  color: '$gray11',
   br: '$2',
   boxShadow: '0px 0px 33px rgba(0, 0, 0, 0.08)',
   position: 'fixed',


### PR DESCRIPTION
Closes #435 