### PR TITLE
fix: editor header showing over settings modal

### DIFF
--- a/.changeset/spotty-countries-fry.md
+++ b/.changeset/spotty-countries-fry.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix editor header appearing over settings dialog.

--- a/sigle/src/modules/editor/EditorHeader.tsx
+++ b/sigle/src/modules/editor/EditorHeader.tsx
@@ -60,12 +60,12 @@ export const EditorHeader = ({
   return (
     <Flex
       css={{
-        position: 'sticky',
+        position: window.scrollY < 40 ? 'relative' : 'sticky',
         transform: scroll.direction === 'down' ? 'translateY(-100%)' : 'none',
         transition: 'transform 0.5s, padding 0.2s',
         backgroundColor: '$gray1',
         top: window.scrollY < 40 ? 'auto' : 0,
-        zIndex: 1,
+        zIndex: window.scrollY < 40 ? 0 : 1,
         width: '100%',
         py: window.scrollY < 40 ? 0 : '$2',
         boxShadow: window.scrollY < 40 ? 'none' : '0 1px 0 0 $colors$gray6',


### PR DESCRIPTION
Given the fact users are unable to scroll when the overlay is active, adding some logic to enable the needed `position: sticky` and `zIndex: 1` properties only when the scroll position is at a certain height seems solve the issue. 

Will raise the issue to the Radix team anyway 👍

Closes #440 