### PR TITLE
fix: dialog portal issue

### DIFF
--- a/.changeset/sixty-dragons-attack.md
+++ b/.changeset/sixty-dragons-attack.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix source of the issue with editor header appearing over settings dialog.

--- a/sigle/src/modules/editor/EditorHeader.tsx
+++ b/sigle/src/modules/editor/EditorHeader.tsx
@@ -60,12 +60,12 @@ export const EditorHeader = ({
   return (
     <Flex
       css={{
-        position: window.scrollY < 40 ? 'relative' : 'sticky',
+        position: 'sticky',
         transform: scroll.direction === 'down' ? 'translateY(-100%)' : 'none',
         transition: 'transform 0.5s, padding 0.2s',
         backgroundColor: '$gray1',
         top: window.scrollY < 40 ? 'auto' : 0,
-        zIndex: window.scrollY < 40 ? 0 : 1,
+        zIndex: 1,
         width: '100%',
         py: window.scrollY < 40 ? 0 : '$2',
         boxShadow: window.scrollY < 40 ? 'none' : '0 1px 0 0 $colors$gray6',

--- a/sigle/src/pages/_app.tsx
+++ b/sigle/src/pages/_app.tsx
@@ -65,6 +65,11 @@ const GlobalStyle = globalCss({
     height: '100%',
   },
 
+  '#__next': {
+    position: 'relative',
+    zIndex: 0,
+  },
+
   body: {
     fontFamily: '$openSans',
     backgroundColor: '$gray1',

--- a/sigle/src/ui/Dialog.tsx
+++ b/sigle/src/ui/Dialog.tsx
@@ -29,8 +29,10 @@ type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
 export function Dialog({ children, ...props }: DialogProps) {
   return (
     <DialogPrimitive.Root {...props}>
-      <StyledOverlay />
-      {children}
+      <DialogPrimitive.Portal>
+        <StyledOverlay />
+        {children}
+      </DialogPrimitive.Portal>
     </DialogPrimitive.Root>
   );
 }


### PR DESCRIPTION
Although the previous fix took care of the header appearing over settings at the top of the page, once further down the page and trying to access the settings, the bug remained like so:
![Screenshot 2022-04-27 at 12 24 54](https://user-images.githubusercontent.com/65421744/165508180-c984d9a3-3913-4ee2-93fe-7a74a954ad5d.png)


After some digging, I came across [this](https://discord.com/channels/752614004387610674/803656530259738674/918963737610838078) from the Radix help discord channel - so following the advice given there to set a new stacking context at root in conjunction with the Dialog Portal has now solved the issue :) 