### PR TITLE
feat: analytics referrers

### DIFF
--- a/.changeset/selfish-bananas-lie.md
+++ b/.changeset/selfish-bananas-lie.md
@@ -1,5 +1,5 @@
 ---
-'@sigle/app': minor
+'@sigle/app': patch
 ---
 
-Create UI with dummy data for referrers on analytics page.
+(Beta) Create UI with dummy data for referrers on analytics page.

--- a/.changeset/selfish-bananas-lie.md
+++ b/.changeset/selfish-bananas-lie.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': minor
+---
+
+Create UI with dummy data for referrers on analytics page.

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -111,6 +111,7 @@ export const ReferrersFrame = () => {
   const getPercentage = (views: number) => {
     const percentage = Math.round((100 * views) / total);
     const lessThanTenPercent = percentage < 10;
+    // clamp min value to 10% - see https://github.com/sigle/sigle/issues/451 for context
     return lessThanTenPercent ? percentage + 10 : percentage;
   };
 

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -14,62 +14,62 @@ const referrersMock: ReferrersItemProps[] = [
   {
     name: 'app.blockstack.org',
     views: 832,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 1,
   },
   {
     name: 'Facebook',
     views: 421,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 2,
   },
   {
     name: 'Twitter',
     views: 124,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 3,
   },
   {
     name: 'Instagram',
     views: 92,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 4,
   },
   {
     name: 'Medium',
     views: 85,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 5,
   },
   {
     name: 'Google',
     views: 63,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 6,
   },
   {
     name: 'linktr.ee',
     views: 60,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 7,
   },
   {
     name: 'DuckDuckGo',
     views: 42,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 8,
   },
   {
     name: 'Linkedin',
     views: 39,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 9,
   },
   {
     name: 'Reddit',
     views: 12,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 10,
   },
   {
     name: 'Substack',
     views: 10,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 11,
   },
   {
     name: 'Yahoo!',
     views: 6,
-    id: Math.floor(Math.random() * Date.now() * 100),
+    id: 12,
   },
 ];
 
@@ -89,7 +89,7 @@ export const ReferrersFrame = () => {
     play();
   }, [currentPage]);
 
-  // how many stories we should show on each page
+  // amount of referres per page
   let itemSize = 10;
 
   const currentReferrers = useMemo(() => {
@@ -108,13 +108,10 @@ export const ReferrersFrame = () => {
     referrersMock &&
     referrersMock.map((item) => item.views).reduce((a, b) => a + b);
 
-  // clamp min value to 10% - see https://github.com/sigle/sigle/issues/451 for context
-  const clamp = (num: number, min: number, max: number) =>
-    Math.min(Math.max(num, min), max);
-
   const getPercentage = (views: number) => {
     const percentage = Math.round((100 * views) / total);
-    return clamp(percentage, 10, percentage);
+    const lessThanTenPercent = percentage < 10;
+    return lessThanTenPercent ? percentage + 10 : percentage;
   };
 
   return (
@@ -145,7 +142,6 @@ export const ReferrersFrame = () => {
                     p: '$1',
                     br: '$1',
                     backgroundColor: '$gray3',
-                    minWidth: 40,
                     width: `${getPercentage(referrer.views)}%`,
                   }}
                 >

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -1,0 +1,171 @@
+import { stagger } from 'motion';
+import { useMotionAnimate } from 'motion-hooks';
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Flex, Text } from '../../ui';
+import { Pagination } from './Pagination';
+
+interface ReferrersItemProps {
+  name: string;
+  views: number;
+  id: number;
+}
+
+const referrersMock: ReferrersItemProps[] = [
+  {
+    name: 'app.blockstack.org',
+    views: 832,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Facebook',
+    views: 421,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Twitter',
+    views: 124,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Instagram',
+    views: 92,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Medium',
+    views: 85,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Google',
+    views: 63,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'linktr.ee',
+    views: 60,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'DuckDuckGo',
+    views: 42,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Linkedin',
+    views: 39,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Reddit',
+    views: 12,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Substack',
+    views: 10,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+  {
+    name: 'Yahoo!',
+    views: 6,
+    id: Math.floor(Math.random() * Date.now() * 100),
+  },
+];
+
+export const ReferrersFrame = () => {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const { play } = useMotionAnimate(
+    '.referrer-item',
+    { opacity: 1 },
+    {
+      delay: stagger(0.075),
+      duration: 0.5,
+      easing: 'ease-in-out',
+    }
+  );
+
+  useEffect(() => {
+    play();
+  }, [currentPage]);
+
+  // how many stories we should show on each page
+  let itemSize = 10;
+
+  const currentReferrers = useMemo(() => {
+    const firstPageIndex = (currentPage - 1) * itemSize;
+    const lastPageIndex = firstPageIndex + itemSize;
+    return referrersMock.slice(firstPageIndex, lastPageIndex);
+  }, [currentPage]);
+
+  const hasNextPage =
+    currentReferrers[currentReferrers.length - 1] ===
+    referrersMock[referrersMock.length - 1]
+      ? false
+      : true;
+
+  const total =
+    referrersMock &&
+    referrersMock.map((item) => item.views).reduce((a, b) => a + b);
+
+  // clamp min value to 10% - see https://github.com/sigle/sigle/issues/451 for context
+  const clamp = (num: number, min: number, max: number) =>
+    Math.min(Math.max(num, min), max);
+
+  const getPercentage = (views: number) => {
+    const percentage = Math.round((100 * views) / total);
+    return clamp(percentage, 10, percentage);
+  };
+
+  return (
+    <>
+      {currentReferrers ? (
+        <Flex
+          css={{ flexShrink: 0, mb: '$4', height: 464 }}
+          direction="column"
+          gap="5"
+        >
+          {currentReferrers.map((referrer) => (
+            <Flex
+              className="referrer-item"
+              css={{ opacity: 0 }}
+              key={referrer.id}
+              gap="5"
+              justify="between"
+              align="center"
+            >
+              <Box
+                css={{
+                  flex: 1,
+                  width: 180,
+                }}
+              >
+                <Box
+                  css={{
+                    p: '$1',
+                    br: '$1',
+                    backgroundColor: '$gray3',
+                    minWidth: 40,
+                    width: `${getPercentage(referrer.views)}%`,
+                  }}
+                >
+                  <Text size="sm">{referrer.name}</Text>
+                </Box>
+              </Box>
+              <Text size="sm">{referrer.views}</Text>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        <Box css={{ display: 'grid', placeItems: 'center', height: '100%' }}>
+          <Text>No data to display</Text>
+        </Box>
+      )}
+      <Pagination
+        currentPage={currentPage}
+        onPageChange={(page) => setCurrentPage(page)}
+        hasNextPage={hasNextPage}
+      />
+    </>
+  );
+};

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -135,7 +135,6 @@ export const ReferrersFrame = () => {
               <Box
                 css={{
                   flex: 1,
-                  width: 180,
                 }}
               >
                 <Box

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -19,7 +19,7 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
       >
         <Box>
           <Heading as="h3" css={{ mb: '$3', fontSize: 15, fontWeight: 600 }}>
-            ={`My published stories (${nbStoriesLabel})`}
+            {`My published stories (${nbStoriesLabel})`}
           </Heading>
           {stories && <PublishedStoriesFrame stories={stories} />}
         </Box>

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -13,13 +13,13 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
   const nbStoriesLabel = loading ? '...' : stories ? stories.length : 0;
 
   return (
-    <DashboardLayout>
+    <DashboardLayout layout="wide">
       <Box
         css={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '$10' }}
       >
         <Box>
           <Heading as="h3" css={{ mb: '$3', fontSize: 15, fontWeight: 600 }}>
-            {`My published stories (${nbStoriesLabel})`}
+            ={`My published stories (${nbStoriesLabel})`}
           </Heading>
           {stories && <PublishedStoriesFrame stories={stories} />}
         </Box>

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -1,7 +1,8 @@
 import { SubsetStory } from '../../../types';
-import { Heading, Text } from '../../../ui';
+import { Box, Flex, Heading, Text } from '../../../ui';
 import { DashboardLayout } from '../../layout';
 import { PublishedStoriesFrame } from '../PublishedStoriesFrame';
+import { ReferrersFrame } from '../ReferrersFrame';
 
 interface AnalyticsProps {
   stories: SubsetStory[] | null;
@@ -13,10 +14,27 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
 
   return (
     <DashboardLayout>
-      <Heading as="h3" css={{ mb: '$3', fontSize: 15, fontWeight: 600 }}>
-        {`My published stories (${nbStoriesLabel})`}
-      </Heading>
-      {stories && <PublishedStoriesFrame stories={stories} />}
+      <Box
+        css={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '$10' }}
+      >
+        <Box>
+          <Heading as="h3" css={{ mb: '$3', fontSize: 15, fontWeight: 600 }}>
+            {`My published stories (${nbStoriesLabel})`}
+          </Heading>
+          {stories && <PublishedStoriesFrame stories={stories} />}
+        </Box>
+        <Box css={{ flexGrow: 1 }}>
+          <Flex css={{ mb: '$5' }} justify="between">
+            <Heading as="h3" css={{ fontSize: 15, fontWeight: 600 }}>
+              Referrers
+            </Heading>
+            <Heading as="h3" css={{ fontSize: 15, fontWeight: 600 }}>
+              Views
+            </Heading>
+          </Flex>
+          <ReferrersFrame />
+        </Box>
+      </Box>
     </DashboardLayout>
   );
 };

--- a/sigle/src/modules/layout/components/DashboardLayout.tsx
+++ b/sigle/src/modules/layout/components/DashboardLayout.tsx
@@ -12,6 +12,40 @@ import {
   AccordionTrigger,
 } from '../../../ui/Accordion';
 import { isExperimentalAnalyticsPageEnabled } from '../../../utils/featureFlags';
+import { VariantProps } from '@stitches/react';
+
+const DashboardContainer = styled(Container, {
+  flex: 1,
+  mt: '$10',
+  width: '100%',
+  display: 'grid',
+
+  '@md': {
+    justifyContent: 'center',
+    gridTemplateColumns: '724px',
+  },
+
+  '@lg': {
+    gridTemplateColumns: '834px',
+  },
+
+  variants: {
+    layout: {
+      default: {
+        '@xl': {
+          gridTemplateColumns: '1fr 826px 1fr',
+        },
+      },
+      wide: {
+        gridTemplateColumns: '1fr 5fr',
+      },
+    },
+  },
+
+  defaultVariants: {
+    layout: 'default',
+  },
+});
 
 const FullScreen = styled('div', {
   height: '100vh',
@@ -59,11 +93,14 @@ const NavItem = styled('a', {
   },
 });
 
-interface DashboardLayoutProps {
+interface DashboardLayoutProps extends VariantProps<typeof DashboardContainer> {
   children: React.ReactNode;
 }
 
-export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
+export const DashboardLayout = ({
+  children,
+  ...props
+}: DashboardLayoutProps) => {
   const router = useRouter();
 
   let triggerName;
@@ -89,27 +126,7 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
   return (
     <FullScreen>
       <AppHeader />
-      <Container
-        css={{
-          display: 'grid',
-          flex: 1,
-          mt: '$10',
-          width: '100%',
-
-          '@md': {
-            justifyContent: 'center',
-            gridTemplateColumns: '724px',
-          },
-
-          '@lg': {
-            gridTemplateColumns: '834px',
-          },
-
-          '@xl': {
-            gridTemplateColumns: '1fr 826px 1fr',
-          },
-        }}
-      >
+      <DashboardContainer {...props}>
         <Sidebar
           css={{
             display: 'none',
@@ -170,10 +187,9 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
               </AccordionContent>
             </AccordionItem>
           </Accordion>
-
           {children}
         </Box>
-      </Container>
+      </DashboardContainer>
       <AppFooter />
     </FullScreen>
   );


### PR DESCRIPTION
Adds referrers with dummy data to the analytics page. 

Enable analytics page by adding `?experimentalAnalyticsPage=true` at the end of the root URL.

Closes #451 