### PR TITLE
chore: refactor analytics and fix some issues

### DIFF
--- a/sigle/src/hooks/analytics.ts
+++ b/sigle/src/hooks/analytics.ts
@@ -4,26 +4,28 @@ import {
   AnalyticsHistoricalResponse,
   ReferrersResponse,
 } from '../modules/analytics/stats/types';
-import { FATHOM_MAX_FROM_DATE } from '../modules/analytics/stats/utils';
 
-export const useGetReferrers = () =>
-  useQuery<ReferrersResponse, Error>('get-analytics-referrer', async () => {
-    const res = await fetch(
-      `${sigleConfig.apiUrl}/api/analytics/referrers?dateFrom=${FATHOM_MAX_FROM_DATE}`,
-      {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+export const useGetReferrers = ({ dateFrom }: { dateFrom: string }) =>
+  useQuery<ReferrersResponse, Error>(
+    ['get-analytics-referrer', dateFrom],
+    async () => {
+      const res = await fetch(
+        `${sigleConfig.apiUrl}/api/analytics/referrers?dateFrom=${dateFrom}`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      const json = await res.json();
+      if (!res.ok) {
+        throw json;
       }
-    );
-    const json = await res.json();
-    if (!res.ok) {
-      throw json;
+      return json;
     }
-    return json;
-  });
+  );
 
 export const useGetHistorical = (
   {

--- a/sigle/src/hooks/analytics.ts
+++ b/sigle/src/hooks/analytics.ts
@@ -1,6 +1,9 @@
-import { useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import { sigleConfig } from '../config';
-import { ReferrersResponse } from '../modules/analytics/stats/types';
+import {
+  AnalyticsHistoricalResponse,
+  ReferrersResponse,
+} from '../modules/analytics/stats/types';
 import { FATHOM_MAX_FROM_DATE } from '../modules/analytics/stats/utils';
 
 export const useGetReferrers = () =>
@@ -21,3 +24,39 @@ export const useGetReferrers = () =>
     }
     return json;
   });
+
+export const useGetHistorical = (
+  {
+    dateFrom,
+    dateGrouping,
+    storyId,
+  }: {
+    dateFrom: string;
+    dateGrouping: 'day' | 'month';
+    storyId?: string;
+  },
+  options: UseQueryOptions<AnalyticsHistoricalResponse, Error>
+) =>
+  useQuery<AnalyticsHistoricalResponse, Error>(
+    ['get-analytics-historical', dateFrom, dateGrouping, storyId],
+    async () => {
+      const res = await fetch(
+        storyId
+          ? `${sigleConfig.apiUrl}/api/analytics/historical?dateFrom=${dateFrom}&dateGrouping=${dateGrouping}&storyId=${storyId}`
+          : `${sigleConfig.apiUrl}/api/analytics/historical?dateFrom=${dateFrom}&dateGrouping=${dateGrouping}`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      const json = await res.json();
+      if (!res.ok) {
+        throw json;
+      }
+      return json;
+    },
+    options
+  );

--- a/sigle/src/hooks/analytics.ts
+++ b/sigle/src/hooks/analytics.ts
@@ -5,12 +5,20 @@ import {
   ReferrersResponse,
 } from '../modules/analytics/stats/types';
 
-export const useGetReferrers = ({ dateFrom }: { dateFrom: string }) =>
+export const useGetReferrers = ({
+  dateFrom,
+  storyId,
+}: {
+  dateFrom: string;
+  storyId?: string;
+}) =>
   useQuery<ReferrersResponse, Error>(
-    ['get-analytics-referrer', dateFrom],
+    ['get-analytics-referrer', dateFrom, storyId],
     async () => {
       const res = await fetch(
-        `${sigleConfig.apiUrl}/api/analytics/referrers?dateFrom=${dateFrom}`,
+        storyId
+          ? `${sigleConfig.apiUrl}/api/analytics/referrers?dateFrom=${dateFrom}&storyId=${storyId}`
+          : `${sigleConfig.apiUrl}/api/analytics/referrers?dateFrom=${dateFrom}`,
         {
           method: 'GET',
           credentials: 'include',

--- a/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
+++ b/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
@@ -23,7 +23,6 @@ export const PublishedStoriesFrame = ({
 }: PublishedStoriesFrameProps) => {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState<number>(1);
-  // TODO load stories from there instead of taking it from props?
   const {
     data: historicalData,
     isError,

--- a/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
+++ b/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
@@ -41,26 +41,22 @@ export const PublishedStoriesFrame = ({
       >
         My published stories ({nbStoriesLabel})
       </Typography>
-      {currentStories && (
-        <>
-          <Box css={{ mb: '$3', height: 476 }}>
-            {currentStories?.map((story) => (
-              <PublishedStoryItem
-                onClick={() =>
-                  router.push('/analytics/[storyId]', `/analytics/${story.id}`)
-                }
-                key={story.id}
-                story={story}
-              />
-            ))}
-          </Box>
-          <Pagination
-            currentPage={currentPage}
-            onPageChange={(page) => setCurrentPage(page)}
-            hasNextPage={hasNextPage}
+      <Box css={{ mb: '$3', height: 476 }}>
+        {currentStories?.map((story) => (
+          <PublishedStoryItem
+            onClick={() =>
+              router.push('/analytics/[storyId]', `/analytics/${story.id}`)
+            }
+            key={story.id}
+            story={story}
           />
-        </>
-      )}
+        ))}
+      </Box>
+      <Pagination
+        currentPage={currentPage}
+        onPageChange={(page) => setCurrentPage(page)}
+        hasNextPage={hasNextPage}
+      />
     </Box>
   );
 };

--- a/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
+++ b/sigle/src/modules/analytics/PublishedStoriesFrame.tsx
@@ -1,20 +1,23 @@
 import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
 import { SubsetStory } from '../../types';
-import { Box } from '../../ui';
+import { Box, Typography } from '../../ui';
 import { Pagination } from './Pagination';
 import { PublishedStoryItem } from './PublishedStoryItem';
 
 interface PublishedStoriesFrameProps {
   stories: SubsetStory[];
+  loading: boolean;
 }
 
 export const PublishedStoriesFrame = ({
   stories,
+  loading,
 }: PublishedStoriesFrameProps) => {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState<number>(1);
 
+  const nbStoriesLabel = loading ? '...' : stories ? stories.length : 0;
   // how many stories we should show on each page
   let itemSize = 7;
 
@@ -30,7 +33,14 @@ export const PublishedStoriesFrame = ({
       : true;
 
   return (
-    <>
+    <Box>
+      <Typography
+        as="h3"
+        size="subheading"
+        css={{ fontWeight: 600, color: '$gray11', mb: '$3' }}
+      >
+        My published stories ({nbStoriesLabel})
+      </Typography>
       {currentStories && (
         <>
           <Box css={{ mb: '$3', height: 476 }}>
@@ -51,6 +61,6 @@ export const PublishedStoriesFrame = ({
           />
         </>
       )}
-    </>
+    </Box>
   );
 };

--- a/sigle/src/modules/analytics/PublishedStoryItem.tsx
+++ b/sigle/src/modules/analytics/PublishedStoryItem.tsx
@@ -2,13 +2,9 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons';
 import { stagger } from 'motion';
 import { useMotionAnimate } from 'motion-hooks';
 import { useEffect } from 'react';
-import { useQuery } from 'react-query';
-import { sigleConfig } from '../../config';
 import { styled } from '../../stitches.config';
 import { SubsetStory } from '../../types';
 import { Box, Flex, Text } from '../../ui';
-import { AnalyticsHistoricalResponse } from './stats/types';
-import { FATHOM_MAX_FROM_DATE } from './stats/utils';
 
 const StoryImage = styled('img', {
   objectFit: 'cover',
@@ -18,41 +14,19 @@ const StoryImage = styled('img', {
   br: '$1',
 });
 
-const baseUrl = sigleConfig.apiUrl;
-
-const fetchStoryViews = async (storyId: string) => {
-  const url = `${baseUrl}/api/analytics/historical?dateFrom=${FATHOM_MAX_FROM_DATE}&dateGrouping=month&storyId=${storyId}`;
-
-  const statsRes = await fetch(url, { credentials: 'include' });
-
-  if (!statsRes.ok) {
-    throw new Error(`Error: ${statsRes.status} - ${statsRes.statusText}`);
-  }
-
-  const statsData: AnalyticsHistoricalResponse = await statsRes.json();
-  let views;
-  if (statsData.stories.length > 0) {
-    views = statsData.stories[0].pageviews;
-  } else {
-    views = 0;
-  }
-  return views;
-};
-
 interface PublishedStoryItemProps {
   story: SubsetStory;
   onClick: () => void;
   individualStory?: boolean;
+  pageviews?: number;
 }
 
 export const PublishedStoryItem = ({
   story,
   onClick,
   individualStory = false,
+  pageviews,
 }: PublishedStoryItemProps) => {
-  const { data } = useQuery<number, Error>(['fetchStoryStats'], () =>
-    fetchStoryViews(story.id)
-  );
   const { play } = useMotionAnimate(
     '.story-item',
     { opacity: 1 },
@@ -151,7 +125,7 @@ export const PublishedStoryItem = ({
         <Flex align="center" css={{ gap: '$5', flexShrink: 0 }}>
           {!individualStory && (
             <>
-              <Text size="sm">{data} views</Text>
+              <Text size="sm">{pageviews} views</Text>
               <ArrowRightIcon />
             </>
           )}

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -6,10 +6,19 @@ import { Box, Flex, Typography } from '../../ui';
 import { Pagination } from './Pagination';
 import { StatsError } from './stats/StatsError';
 
-export const ReferrersFrame = () => {
+interface ReferrersFrameProps {
+  historicalParams: {
+    dateFrom: string;
+  };
+}
+
+export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  // TODO should use weekly, monthly, all selection
-  const { data: referrers, isError, error } = useGetReferrers();
+  const {
+    data: referrers,
+    isError,
+    error,
+  } = useGetReferrers({ dateFrom: historicalParams.dateFrom });
   const { play } = useMotionAnimate(
     '.referrer-item',
     { opacity: 1 },

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -30,8 +30,10 @@ export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
   );
 
   useEffect(() => {
-    play();
-  }, [currentPage]);
+    if (referrers) {
+      play();
+    }
+  }, [referrers, currentPage]);
 
   // amount of referres per page
   let itemSize = 10;
@@ -40,7 +42,7 @@ export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
     const firstPageIndex = (currentPage - 1) * itemSize;
     const lastPageIndex = firstPageIndex + itemSize;
     return referrers?.slice(firstPageIndex, lastPageIndex);
-  }, [currentPage]);
+  }, [referrers, currentPage]);
 
   const currentReferrerLastItem =
     currentReferrers && currentReferrers[currentReferrers.length - 1];
@@ -50,9 +52,7 @@ export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
   const hasNextPage =
     currentReferrerLastItem === referrerLastItem ? false : true;
 
-  const total = referrers
-    ? referrers.map((item) => item.count).reduce((a, b) => a + b)
-    : 0;
+  const total = referrers?.reduce((a, b) => a + b.count, 0) ?? 0;
 
   const getPercentage = (views: number) => {
     const percentage = Math.round((100 * views) / total);
@@ -90,7 +90,7 @@ export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
             <Flex
               className="referrer-item"
               css={{ opacity: 0 }}
-              key={referrer.domain}
+              key={`${referrer.domain}-${referrer.count}`}
               gap="5"
               justify="between"
               align="center"

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -8,6 +8,7 @@ import { StatsError } from './stats/StatsError';
 
 export const ReferrersFrame = () => {
   const [currentPage, setCurrentPage] = useState<number>(1);
+  // TODO should use weekly, monthly, all selection
   const { data: referrers, isError, error } = useGetReferrers();
   const { play } = useMotionAnimate(
     '.referrer-item',

--- a/sigle/src/modules/analytics/ReferrersFrame.tsx
+++ b/sigle/src/modules/analytics/ReferrersFrame.tsx
@@ -7,18 +7,22 @@ import { Pagination } from './Pagination';
 import { StatsError } from './stats/StatsError';
 
 interface ReferrersFrameProps {
+  storyId?: string;
   historicalParams: {
     dateFrom: string;
   };
 }
 
-export const ReferrersFrame = ({ historicalParams }: ReferrersFrameProps) => {
+export const ReferrersFrame = ({
+  historicalParams,
+  storyId,
+}: ReferrersFrameProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const {
     data: referrers,
     isError,
     error,
-  } = useGetReferrers({ dateFrom: historicalParams.dateFrom });
+  } = useGetReferrers({ dateFrom: historicalParams.dateFrom, storyId });
   const { play } = useMotionAnimate(
     '.referrer-item',
     { opacity: 1 },

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -77,7 +77,7 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
         {stories && (
           <PublishedStoriesFrame loading={loading} stories={stories} />
         )}
-        <ReferrersFrame />
+        <ReferrersFrame historicalParams={historicalParams} />
       </Box>
     </DashboardLayout>
   );

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -28,12 +28,9 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
           },
         }}
       >
-        <Box>
-          <Heading as="h3" css={{ mb: '$3', fontSize: 15, fontWeight: 600 }}>
-            {`My published stories (${nbStoriesLabel})`}
-          </Heading>
-          {stories && <PublishedStoriesFrame stories={stories} />}
-        </Box>
+        {stories && (
+          <PublishedStoriesFrame loading={loading} stories={stories} />
+        )}
         <ReferrersFrame />
       </Box>
     </DashboardLayout>

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -1,10 +1,17 @@
+import { useState } from 'react';
+import { format } from 'date-fns';
 import { SubsetStory } from '../../../types';
-import { Box, Flex, Heading, Text } from '../../../ui';
+import { Box } from '../../../ui';
 import { DashboardLayout } from '../../layout';
-import { NftLockedView } from '../NftLockedView';
 import { PublishedStoriesFrame } from '../PublishedStoriesFrame';
 import { ReferrersFrame } from '../ReferrersFrame';
 import { StatsFrame } from '../stats/StatsFrame';
+import {
+  FATHOM_MAX_FROM_DATE,
+  monthFromDate,
+  weekFromDate,
+} from '../stats/utils';
+import { StatsType } from '../stats/types';
 
 interface AnalyticsProps {
   stories: SubsetStory[] | null;
@@ -12,11 +19,50 @@ interface AnalyticsProps {
 }
 
 export const Analytics = ({ stories, loading }: AnalyticsProps) => {
-  const nbStoriesLabel = loading ? '...' : stories ? stories.length : 0;
+  const [historicalParams, setHistoricalParams] = useState<{
+    dateFrom: string;
+    dateGrouping: 'day' | 'month';
+    statType: 'all' | 'weekly' | 'monthly';
+  }>(() => ({
+    dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+    dateGrouping: 'day',
+    statType: 'weekly',
+  }));
+
+  const changeHistoricalParams = (value: StatsType) => {
+    switch (value) {
+      case 'weekly':
+        setHistoricalParams({
+          dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'weekly',
+        });
+        break;
+      case 'monthly':
+        setHistoricalParams({
+          dateFrom: format(monthFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'monthly',
+        });
+        break;
+      case 'all':
+        setHistoricalParams({
+          dateFrom: FATHOM_MAX_FROM_DATE,
+          dateGrouping: 'month',
+          statType: 'all',
+        });
+        break;
+      default:
+        throw new Error('No value received.');
+    }
+  };
 
   return (
     <DashboardLayout layout="wide">
-      <StatsFrame />
+      <StatsFrame
+        historicalParams={historicalParams}
+        changeHistoricalParams={changeHistoricalParams}
+      />
       <Box
         css={{
           display: 'flex',

--- a/sigle/src/modules/analytics/components/Analytics.tsx
+++ b/sigle/src/modules/analytics/components/Analytics.tsx
@@ -75,7 +75,11 @@ export const Analytics = ({ stories, loading }: AnalyticsProps) => {
         }}
       >
         {stories && (
-          <PublishedStoriesFrame loading={loading} stories={stories} />
+          <PublishedStoriesFrame
+            historicalParams={historicalParams}
+            loading={loading}
+            stories={stories}
+          />
         )}
         <ReferrersFrame historicalParams={historicalParams} />
       </Box>

--- a/sigle/src/modules/analytics/components/StoryItemAnalytics.tsx
+++ b/sigle/src/modules/analytics/components/StoryItemAnalytics.tsx
@@ -2,17 +2,12 @@ import { format } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { StatsChart } from '../stats/StatsChart';
-import {
-  AnalyticsHistoricalResponse,
-  StatsData,
-  StatsType,
-} from '../stats/types';
+import { StatsType } from '../stats/types';
 import { DashboardLayout } from '../../layout';
-import { Box, Flex, Heading, Tabs, TabsList, TabsTrigger } from '../../../ui';
+import { Box, Flex, Tabs, TabsList, TabsTrigger } from '../../../ui';
 import { SubsetStory } from '../../../types';
 import { PublishedStoryItem } from '../PublishedStoryItem';
 import { ReferrersFrame } from '../ReferrersFrame';
-import { useQuery } from 'react-query';
 import { StatsTotal } from '../stats/StatsTotal';
 import { StatsError } from '../stats/StatsError';
 import {
@@ -21,7 +16,7 @@ import {
   monthFromDate,
   weekFromDate,
 } from '../stats/utils';
-import { sigleConfig } from '../../../config';
+import { useGetHistorical } from '../../../hooks/analytics';
 
 interface StoryAnalyticsProps {
   story: SubsetStory | undefined;
@@ -29,76 +24,54 @@ interface StoryAnalyticsProps {
 
 export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
   const router = useRouter();
-  const [statType, setStatType] = useState<StatsType>('weekly');
-  const { data, isError, error } = useQuery<StatsData[], Error>(
-    ['fetchStoryStats', statType],
-    () => fetchStats(statType),
+
+  // TODO remove after testing
+  if (story) {
+    story.id = 'JA9dBfdPDp7kQhkFkgPdv';
+  }
+
+  const [historicalParams, setHistoricalParams] = useState<{
+    dateFrom: string;
+    dateGrouping: 'day' | 'month';
+    statType: 'all' | 'weekly' | 'monthly';
+  }>(() => ({
+    dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+    dateGrouping: 'day',
+    statType: 'weekly',
+  }));
+  const {
+    data: historicalData,
+    isError,
+    error,
+  } = useGetHistorical(
+    { ...historicalParams, storyId: story?.id },
     {
-      placeholderData: initialRange,
+      placeholderData: { historical: initialRange, stories: [] },
     }
   );
-
-  const baseUrl = sigleConfig.apiUrl;
-
-  // testing on stories that already have views to validate things are working as expected
-  const testId = 'JA9dBfdPDp7kQhkFkgPdv';
-
-  const fetchStats = async (statType: StatsType) => {
-    const weeklyStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${format(
-      weekFromDate,
-      'yyyy-MM-dd'
-    )}&dateGrouping=day&storyId=${testId}`;
-
-    const monthlyStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${format(
-      monthFromDate,
-      'yyyy-MM-dd'
-    )}&dateGrouping=day&storyId=${testId}`;
-
-    const allTimeStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${FATHOM_MAX_FROM_DATE}&dateGrouping=month&storyId=${testId}`;
-    let url;
-
-    switch (statType) {
-      case 'weekly':
-        url = weeklyStatsUrl;
-        break;
-      case 'monthly':
-        url = monthlyStatsUrl;
-        break;
-      case 'all':
-        url = allTimeStatsUrl;
-        break;
-
-      default:
-        throw new Error('No value received.');
-    }
-
-    const statsRes = await fetch(url, { credentials: 'include' });
-
-    if (!statsRes.ok) {
-      throw new Error(`Error: ${statsRes.status} - ${statsRes.statusText}`);
-    }
-
-    const statsData: AnalyticsHistoricalResponse = await statsRes.json();
-    const stats: StatsData[] = statsData.historical.map((item) => {
-      return {
-        pageviews: item.pageviews,
-        date: item.date,
-        visits: item.visits,
-      };
-    });
-    return stats;
-  };
+  const data = historicalData?.historical;
 
   const checkStatType = (value: StatsType) => {
     switch (value) {
       case 'weekly':
-        setStatType('weekly');
-        break;
+        setHistoricalParams({
+          dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'weekly',
+        });
       case 'monthly':
-        setStatType('monthly');
+        setHistoricalParams({
+          dateFrom: format(monthFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'monthly',
+        });
         break;
       case 'all':
-        setStatType('all');
+        setHistoricalParams({
+          dateFrom: FATHOM_MAX_FROM_DATE,
+          dateGrouping: 'month',
+          statType: 'all',
+        });
         break;
       default:
         throw new Error('No value received.');
@@ -140,7 +113,7 @@ export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
               height: 400,
             }}
           >
-            <StatsChart type={statType} data={data!} />
+            <StatsChart type={historicalParams.statType} data={data!} />
           </Box>
         </Tabs>
       </Flex>

--- a/sigle/src/modules/analytics/components/StoryItemAnalytics.tsx
+++ b/sigle/src/modules/analytics/components/StoryItemAnalytics.tsx
@@ -51,7 +51,7 @@ export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
   );
   const data = historicalData?.historical;
 
-  const checkStatType = (value: StatsType) => {
+  const changeHistoricalParams = (value: StatsType) => {
     switch (value) {
       case 'weekly':
         setHistoricalParams({
@@ -59,6 +59,7 @@ export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
           dateGrouping: 'day',
           statType: 'weekly',
         });
+        break;
       case 'monthly':
         setHistoricalParams({
           dateFrom: format(monthFromDate, 'yyyy-MM-dd'),
@@ -93,7 +94,7 @@ export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
       <Flex css={{ mt: '$8' }}>
         <StatsTotal data={data!} />
         <Tabs
-          onValueChange={(value) => checkStatType(value as StatsType)}
+          onValueChange={(value) => changeHistoricalParams(value as StatsType)}
           css={{ width: '100%' }}
           defaultValue="weekly"
         >
@@ -117,7 +118,7 @@ export const StoryItemAnalytics = ({ story }: StoryAnalyticsProps) => {
           </Box>
         </Tabs>
       </Flex>
-      <ReferrersFrame />
+      <ReferrersFrame storyId={story?.id} historicalParams={historicalParams} />
     </DashboardLayout>
   );
 };

--- a/sigle/src/modules/analytics/containers/StoryItemAnalytics.tsx
+++ b/sigle/src/modules/analytics/containers/StoryItemAnalytics.tsx
@@ -20,7 +20,7 @@ export const StoryItemAnalytics = () => {
   const router = useRouter();
   const { storyId } = router.query;
   const { data: story } = useQuery<SubsetStory>(
-    ['loadStoryItem'],
+    ['loadStoryItem', storyId],
     () => loadStoryFile(storyId as string),
     {}
   );

--- a/sigle/src/modules/analytics/stats/StatsFrame.tsx
+++ b/sigle/src/modules/analytics/stats/StatsFrame.tsx
@@ -1,28 +1,24 @@
-import { format } from 'date-fns';
-import { useState } from 'react';
 import { useGetHistorical } from '../../../hooks/analytics';
 import { Box, Flex, Tabs, TabsList, TabsTrigger } from '../../../ui';
 import { StatsChart } from './StatsChart';
 import { StatsError } from './StatsError';
 import { StatsTotal } from './StatsTotal';
 import { StatsType } from './types';
-import {
-  FATHOM_MAX_FROM_DATE,
-  initialRange,
-  monthFromDate,
-  weekFromDate,
-} from './utils';
+import { initialRange } from './utils';
 
-export const StatsFrame = () => {
-  const [historicalParams, setHistoricalParams] = useState<{
+interface StatsFrameProps {
+  historicalParams: {
     dateFrom: string;
     dateGrouping: 'day' | 'month';
     statType: 'all' | 'weekly' | 'monthly';
-  }>(() => ({
-    dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
-    dateGrouping: 'day',
-    statType: 'weekly',
-  }));
+  };
+  changeHistoricalParams(value: StatsType): void;
+}
+
+export const StatsFrame = ({
+  historicalParams,
+  changeHistoricalParams,
+}: StatsFrameProps) => {
   const {
     data: historicalData,
     isError,
@@ -32,41 +28,13 @@ export const StatsFrame = () => {
   });
   const data = historicalData?.historical;
 
-  const checkStatType = (value: StatsType) => {
-    switch (value) {
-      case 'weekly':
-        setHistoricalParams({
-          dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
-          dateGrouping: 'day',
-          statType: 'weekly',
-        });
-        break;
-      case 'monthly':
-        setHistoricalParams({
-          dateFrom: format(monthFromDate, 'yyyy-MM-dd'),
-          dateGrouping: 'day',
-          statType: 'monthly',
-        });
-        break;
-      case 'all':
-        setHistoricalParams({
-          dateFrom: FATHOM_MAX_FROM_DATE,
-          dateGrouping: 'month',
-          statType: 'all',
-        });
-        break;
-      default:
-        throw new Error('No value received.');
-    }
-  };
-
   return (
     <Box css={{ mb: '$8', position: 'relative' }}>
       {isError && <StatsError>{error.message}</StatsError>}
       <Flex>
         <StatsTotal data={data} />
         <Tabs
-          onValueChange={(value) => checkStatType(value as StatsType)}
+          onValueChange={(value) => changeHistoricalParams(value as StatsType)}
           css={{ width: '100%' }}
           defaultValue="weekly"
         >

--- a/sigle/src/modules/analytics/stats/StatsFrame.tsx
+++ b/sigle/src/modules/analytics/stats/StatsFrame.tsx
@@ -1,12 +1,11 @@
 import { format } from 'date-fns';
 import { useState } from 'react';
-import { useQuery } from 'react-query';
-import { sigleConfig } from '../../../config';
+import { useGetHistorical } from '../../../hooks/analytics';
 import { Box, Flex, Tabs, TabsList, TabsTrigger } from '../../../ui';
 import { StatsChart } from './StatsChart';
 import { StatsError } from './StatsError';
 import { StatsTotal } from './StatsTotal';
-import { AnalyticsHistoricalResponse, StatsData, StatsType } from './types';
+import { StatsType } from './types';
 import {
   FATHOM_MAX_FROM_DATE,
   initialRange,
@@ -15,73 +14,46 @@ import {
 } from './utils';
 
 export const StatsFrame = () => {
-  const [statType, setStatType] = useState<StatsType>('weekly');
-  const { data, isError, error } = useQuery<StatsData[], Error>(
-    ['fetchStats', statType],
-    () => fetchStats(statType),
-    {
-      placeholderData: initialRange,
-    }
-  );
-
-  const baseUrl = sigleConfig.apiUrl;
-
-  const fetchStats = async (value: StatsType) => {
-    const weeklyStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${format(
-      weekFromDate,
-      'yyyy-MM-dd'
-    )}&dateGrouping=day`;
-
-    const monthlyStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${format(
-      monthFromDate,
-      'yyyy-MM-dd'
-    )}&dateGrouping=day`;
-
-    const allTimeStatsUrl = `${baseUrl}/api/analytics/historical?dateFrom=${FATHOM_MAX_FROM_DATE}&dateGrouping=month`;
-    let url;
-
-    switch (value) {
-      case 'weekly':
-        url = weeklyStatsUrl;
-        break;
-      case 'monthly':
-        url = monthlyStatsUrl;
-        break;
-      case 'all':
-        url = allTimeStatsUrl;
-        break;
-
-      default:
-        throw new Error('No value received.');
-    }
-
-    const statsRes = await fetch(url, { credentials: 'include' });
-
-    if (!statsRes.ok) {
-      throw new Error(`Error: ${statsRes.status} - ${statsRes.statusText}`);
-    }
-
-    const statsData: AnalyticsHistoricalResponse = await statsRes.json();
-    const stats: StatsData[] = statsData.historical.map((item) => {
-      return {
-        pageviews: item.pageviews,
-        date: item.date,
-        visits: item.visits,
-      };
-    });
-    return stats;
-  };
+  const [historicalParams, setHistoricalParams] = useState<{
+    dateFrom: string;
+    dateGrouping: 'day' | 'month';
+    statType: 'all' | 'weekly' | 'monthly';
+  }>(() => ({
+    dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+    dateGrouping: 'day',
+    statType: 'weekly',
+  }));
+  const {
+    data: historicalData,
+    isError,
+    error,
+  } = useGetHistorical(historicalParams, {
+    placeholderData: { historical: initialRange, stories: [] },
+  });
+  const data = historicalData?.historical;
 
   const checkStatType = (value: StatsType) => {
     switch (value) {
       case 'weekly':
-        setStatType('weekly');
+        setHistoricalParams({
+          dateFrom: format(weekFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'weekly',
+        });
         break;
       case 'monthly':
-        setStatType('monthly');
+        setHistoricalParams({
+          dateFrom: format(monthFromDate, 'yyyy-MM-dd'),
+          dateGrouping: 'day',
+          statType: 'monthly',
+        });
         break;
       case 'all':
-        setStatType('all');
+        setHistoricalParams({
+          dateFrom: FATHOM_MAX_FROM_DATE,
+          dateGrouping: 'month',
+          statType: 'all',
+        });
         break;
       default:
         throw new Error('No value received.');
@@ -114,7 +86,7 @@ export const StatsFrame = () => {
               height: 400,
             }}
           >
-            <StatsChart type={statType} data={data} />
+            <StatsChart type={historicalParams.statType} data={data} />
           </Box>
         </Tabs>
       </Flex>

--- a/sigle/src/pages/_app.page.tsx
+++ b/sigle/src/pages/_app.page.tsx
@@ -25,7 +25,14 @@ import { darkTheme, globalCss } from '../stitches.config';
 import { ThemeProvider } from 'next-themes';
 import { FeatureFlagsProvider } from '../utils/featureFlags';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
 
 /**
  * Fathom


### PR DESCRIPTION
- [x] Referrers should be using the filters to make the request to the server
- [x] Fix referrers list not updating when filters were changing (due to animation not triggering)
- [x] Referrers should be using the story ID when on individual story stats
- [x] Refactor Stats to avoid duplicated logic
- [x] PublishedStory frame should make just one request instead of many per row to avoid hitting the server too much and also use filters
- [x] Match stories with data coming from the API in the PublishedStory list 