### PR TITLE
fix: fix chart issue when selecting all

### DIFF
--- a/.changeset/cuddly-jars-reply.md
+++ b/.changeset/cuddly-jars-reply.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix issue when selecting all in the stats view.

--- a/server/src/api/modules/analytics/historical.test.ts
+++ b/server/src/api/modules/analytics/historical.test.ts
@@ -200,7 +200,7 @@ it('Respond with a formatted time series for months', async () => {
   expect(response.json()).toMatchSnapshot();
   expect(plausibleClient.timeseries).toBeCalledWith({
     dateFrom: '2022-05-01',
-    dateGrouping: 'month',
+    dateGrouping: 'day',
     dateTo: '2022-04-04',
     paths: expect.any(Array),
   });

--- a/server/src/api/modules/analytics/historical.ts
+++ b/server/src/api/modules/analytics/historical.ts
@@ -163,7 +163,10 @@ export async function createAnalyticsHistoricalEndpoint(
 
       const plausibleResults = await plausibleClient.timeseries({
         dateFrom,
-        dateGrouping,
+        // TODO enable this part again once we start having more data in
+        // For now we always default to day grouping for a few months
+        // dateGrouping,
+        dateGrouping: 'day',
         dateTo: format(dateTo, 'yyyy-MM-dd'),
         paths: storiesPath,
       });

--- a/sigle/src/modules/analytics/stats/StatsChart.tsx
+++ b/sigle/src/modules/analytics/stats/StatsChart.tsx
@@ -39,12 +39,14 @@ const StatsChart = ({
     right: 0,
   };
 
-  const tickFormat = (d: any) => {
-    if (type === 'weekly' || type === 'monthly') {
-      return format(d, 'dd/MM');
-    } else {
-      return format(d, 'MMM yyyy');
-    }
+  const tickFormat = (d: Date) => {
+    return format(d, 'dd/MM');
+    // TODO enable this part again once we start having more data in
+    // if (type === 'weekly' || type === 'monthly') {
+    //   return format(d, 'dd/MM');
+    // } else {
+    //   return format(d, 'MMM yyyy');
+    // }
   };
 
   // bounds
@@ -73,7 +75,6 @@ const StatsChart = ({
     return scaleLinear({
       range: [yMax, margin.top],
       domain: [0, maxValue ? maxValue : 10],
-      nice: true,
     });
   }, [yMax, margin.top, data]);
 


### PR DESCRIPTION
There is an issue when selecting "all" in the current implementation, as we have only a few weeks of data it fails to render the months properly.
For a few month, we will show the 'all' data as daily events, then we can switch back to how it was before.