### PR TITLE
fix: make tooltip delay duration more instant

### DIFF
--- a/.changeset/dirty-pots-battle.md
+++ b/.changeset/dirty-pots-battle.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Update the delay duration of the Tooltip on the Compare Plans page.

--- a/sigle/src/modules/settings/plans/ComparePlans.tsx
+++ b/sigle/src/modules/settings/plans/ComparePlans.tsx
@@ -287,7 +287,7 @@ export const ComparePlans = () => {
               >
                 <Flex gap="10" justify="between" align="center">
                   <Typography size="subheading">{feature.name}</Typography>
-                  <Tooltip>
+                  <Tooltip delayDuration={100}>
                     <TooltipTrigger>
                       <QuestionMarkCircledIcon />
                     </TooltipTrigger>


### PR DESCRIPTION
This pr updates the delay duration for the tooltip on the "Compare plans" page. 

Fixes #570 