### PR TITLE
feat: index legacy users

### DIFF
--- a/.changeset/brown-schools-pay.md
+++ b/.changeset/brown-schools-pay.md
@@ -1,0 +1,5 @@
+---
+'@sigle/server': minor
+---
+
+Save legacy users to the indexer.

--- a/server/prisma/migrations/20220718165354_added_user_legacy/migration.sql
+++ b/server/prisma/migrations/20220718165354_added_user_legacy/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isLegacy" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -8,11 +8,12 @@ datasource db {
 }
 
 model User {
-  id             String         @id @default(uuid())
-  stacksAddress  String         @unique
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  subscriptions  Subscription[]
+  id            String         @id @default(uuid())
+  stacksAddress String         @unique
+  isLegacy      Boolean        @default(false)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  subscriptions Subscription[]
 }
 
 model Subscription {

--- a/server/src/api/modules/users/[userId].ts
+++ b/server/src/api/modules/users/[userId].ts
@@ -87,7 +87,7 @@ export async function createGetUserByAddressEndpoint(fastify: FastifyInstance) {
         if (token && token.sub) {
           const newUser = await prisma.user.create({
             data: {
-              stacksAddress: req.address,
+              stacksAddress: userAddress,
               isLegacy: true,
             },
           });

--- a/server/src/api/modules/users/[userId].ts
+++ b/server/src/api/modules/users/[userId].ts
@@ -1,4 +1,6 @@
 import { FastifyInstance } from 'fastify';
+import { getToken } from 'next-auth/jwt';
+import { config } from '../../../config';
 import { prisma } from '../../../prisma';
 
 type GetUserByAddressResponse = {
@@ -70,6 +72,28 @@ export async function createGetUserByAddressEndpoint(fastify: FastifyInstance) {
           },
         },
       });
+
+      /**
+       * If user is not found in database, it means it's a legacy user using blockstack connect.
+       * As we can't create sessions for these kind of users, we check if the current user is logged in
+       * and add the legacy user to the database if it's the case.
+       */
+      if (!user) {
+        const token = await getToken({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          req: req as any,
+          secret: config.NEXTAUTH_SECRET,
+        });
+        if (token && token.sub) {
+          const newUser = await prisma.user.create({
+            data: {
+              stacksAddress: req.address,
+              isLegacy: true,
+            },
+          });
+          return newUser;
+        }
+      }
 
       return res.send(
         user


### PR DESCRIPTION
Right now we just save to the DB users that signed a message, we should also save the legacy users so the relations are not broken in the DB