### PR TITLE
feat: optimise hover card data fetching

### DIFF
--- a/sigle/src/modules/profileCard/ProfileCard.tsx
+++ b/sigle/src/modules/profileCard/ProfileCard.tsx
@@ -64,15 +64,19 @@ export const ProfileCard = ({
   const [isOpen, setIsOpen] = useState(false);
   const { data: userFollowing } = useGetGaiaUserFollowing({
     enabled: isOpen && !!user && userInfo.username !== user.username,
+    staleTime: Infinity,
   });
   const { data: userInfoByAddress } = useGetUserByAddress(userInfo.address, {
     enabled: isOpen,
+    staleTime: Infinity,
   });
   const { data: following } = useGetUsersFollowing(userInfo.address, {
     enabled: isOpen,
+    staleTime: Infinity,
   });
   const { data: followers } = useGetUsersFollowers(userInfo.address, {
     enabled: isOpen,
+    staleTime: Infinity,
   });
   const { mutate: followUser } = useUserFollow();
   const { mutate: unfollowUser } = useUserUnfollow();


### PR DESCRIPTION
Right now every time you open the card, requests are made to fetch the latest data to the server, even tho the data didn't change. With this change, the data is fetched once the card is opened and then the cache is used when it's reopened.