### PR TITLE
chore: DO NOT MERGE - bypass profile verification

### DIFF
--- a/sigle/src/pages/[username]/[storyId].page.tsx
+++ b/sigle/src/pages/[username]/[storyId].page.tsx
@@ -104,7 +104,7 @@ export const getServerSideProps: GetServerSideProps<
     if (nameInfo) {
       userProfile = await resolveZoneFileToProfile(
         nameInfo.zonefile,
-        nameInfo.address
+        '029e4f662047ae53319fcfe393d3a2c41147e606efda3e192ac7f9d4c8d505602a'
       );
     }
   } catch (error) {

--- a/sigle/src/pages/[username]/[storyId].page.tsx
+++ b/sigle/src/pages/[username]/[storyId].page.tsx
@@ -11,7 +11,6 @@ import Error from '../_error.page';
 import { PublicStory } from '../../modules/publicStory/PublicStory';
 import { Story, SettingsFile } from '../../types';
 import { migrationStory } from '../../utils/migrations/story';
-import { sigleConfig } from '../../config';
 
 interface PublicStoryPageProps {
   statusCode: number | boolean;
@@ -105,7 +104,7 @@ export const getServerSideProps: GetServerSideProps<
     if (nameInfo) {
       userProfile = await resolveZoneFileToProfile(
         nameInfo.zonefile,
-        '029e4f662047ae53319fcfe393d3a2c41147e606efda3e192ac7f9d4c8d505602a'
+        nameInfo.address
       );
     }
   } catch (error) {

--- a/sigle/src/pages/[username]/[storyId].page.tsx
+++ b/sigle/src/pages/[username]/[storyId].page.tsx
@@ -71,7 +71,7 @@ const fetchSettings = async (
 
 export const getServerSideProps: GetServerSideProps<
   PublicStoryPageProps
-> = async ({ req, res, params }) => {
+> = async ({ res, params }) => {
   const username = params?.username as string;
   const storyId = params?.storyId as string;
 

--- a/sigle/src/pages/[username]/[storyId].page.tsx
+++ b/sigle/src/pages/[username]/[storyId].page.tsx
@@ -105,7 +105,7 @@ export const getServerSideProps: GetServerSideProps<
     if (nameInfo) {
       userProfile = await resolveZoneFileToProfile(
         nameInfo.zonefile,
-        nameInfo.address
+        '029e4f662047ae53319fcfe393d3a2c41147e606efda3e192ac7f9d4c8d505602a'
       );
     }
   } catch (error) {
@@ -121,12 +121,7 @@ export const getServerSideProps: GetServerSideProps<
 
   // If deployed on vercel we want to get the deployment url to be able to test unmerged pr's
   // If client side we use window.location.origin
-  const appUrl = req.headers['x-forwarded-host']
-    ? // ? `${req.headers['x-forwarded-proto']}://${req.headers['x-forwarded-host']}`
-      `https://${req.headers['x-forwarded-host']}`
-    : req.headers.host === 'localhost:3000'
-    ? 'http://localhost:3000'
-    : sigleConfig.appUrl;
+  const appUrl = 'https://app.sigle.io';
 
   const bucketUrl = userProfile?.apps?.[appUrl];
   // If the user already used the app we try to get the public list


### PR DESCRIPTION
# ⚠️ DO NOT MERGE

Used to help users recover content with `Token issuer public key does not match the verifying value` error