### PR TITLE
feat: improve editor placeholder behavior

### DIFF
--- a/.changeset/shy-pans-vanish.md
+++ b/.changeset/shy-pans-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': minor
+---
+
+Improve the editor placeholder behavior to give more context.

--- a/sigle/src/modules/editor/TipTapEditor.tsx
+++ b/sigle/src/modules/editor/TipTapEditor.tsx
@@ -22,7 +22,7 @@ import TipTapLink from '@tiptap/extension-link';
 import TipTapListItem from '@tiptap/extension-list-item';
 import TipTapOrderedList from '@tiptap/extension-ordered-list';
 import TipTapParagraph from '@tiptap/extension-paragraph';
-import TipTapPlaceholder from '@tiptap/extension-placeholder';
+import { Placeholder as TipTapPlaceholder } from './extensions/Placeholder';
 import TipTapStrike from '@tiptap/extension-strike';
 import TipTapText from '@tiptap/extension-text';
 import TipTapUnderline from '@tiptap/extension-underline';
@@ -54,7 +54,7 @@ const StyledEditorContent = styled(EditorContent, {
     outline: 'none',
   },
   // Placeholder plugin style
-  '& .ProseMirror p.is-empty::before': {
+  '& .ProseMirror .is-empty::before': {
     content: 'attr(data-placeholder)',
     float: 'left',
     color: '$gray8',
@@ -170,14 +170,7 @@ export const TipTapEditor = forwardRef<
       // Extensions
       TipTapDropcursor,
       TipTapHistory,
-      TipTapPlaceholder.configure({
-        placeholder: ({ editor }) => {
-          const currentPos = editor.state.selection.$anchor.pos;
-          return currentPos === 1
-            ? 'Start your story here...'
-            : "Type '/' for commands";
-        },
-      }),
+      TipTapPlaceholder,
       // Custom extensions
       SlashCommands.configure({
         commands: slashCommands({ storyId: story.id }),

--- a/sigle/src/modules/editor/extensions/Placeholder/index.ts
+++ b/sigle/src/modules/editor/extensions/Placeholder/index.ts
@@ -1,0 +1,42 @@
+import TipTapPlaceholder from '@tiptap/extension-placeholder';
+
+export const Placeholder = TipTapPlaceholder.configure({
+  showOnlyWhenEditable: true,
+  includeChildren: true,
+  placeholder: ({ editor, node, pos }) => {
+    if (node.type.name === 'heading') {
+      const level = node.attrs.level as number;
+      if (level === 2) {
+        return 'Big Heading';
+      } else if (level === 3) {
+        return 'Small Heading';
+      }
+    }
+
+    if (node.type.name === 'paragraph') {
+      const parentNode = editor.state.doc.resolve(pos).parent;
+      // When user start to write, only show this when the content is empty
+      if (
+        parentNode.type.name === 'doc' &&
+        editor.getJSON().content?.length === 1
+      ) {
+        return 'Start your story here...';
+      }
+
+      if (parentNode.type.name === 'listItem') {
+        return 'List';
+      }
+
+      if (parentNode.type.name === 'blockquote') {
+        if (parentNode.content.childCount > 1) {
+          return 'Type or hit enter to exit quote';
+        }
+        return 'Quote';
+      }
+
+      return "Type '/' for commands";
+    }
+
+    return '';
+  },
+});

--- a/sigle/src/modules/editor/extensions/Placeholder/index.ts
+++ b/sigle/src/modules/editor/extensions/Placeholder/index.ts
@@ -28,6 +28,7 @@ export const Placeholder = TipTapPlaceholder.configure({
       }
 
       if (parentNode.type.name === 'blockquote') {
+        // If there is more than one child in the quote, explain what to do next
         if (parentNode.content.childCount > 1) {
           return 'Type or hit enter to exit quote';
         }


### PR DESCRIPTION
The goal of this pr is to improve the placeholder text based on the block types, this will give more context to the writer.

List of changes:
- when selecting big heading => "Big Heading" placeholder is shown
- when selecting small heading => "Small Heading" placeholder is shown
- fixed an issue for first text when editor is empty
- all lists items => "List" placeholder
- empty quote => "Quote" placeholder
- when quote has more than 2 child => "Type or hit enter to exit quote" placeholder

Example for the quote:
![Screenshot 2022-08-26 at 12 47 01](https://user-images.githubusercontent.com/5749437/186888028-acc76f40-6c07-48c7-9dda-a7506334f53d.png)
