### PR TITLE
feat: cover image drop

### DIFF
--- a/.changeset/many-boats-argue.md
+++ b/.changeset/many-boats-argue.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': minor
+---
+
+Improve the experience of drag and drop for story cover image.

--- a/sigle/src/modules/editor/CoverImage.tsx
+++ b/sigle/src/modules/editor/CoverImage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { CameraIcon, HandIcon, TrashIcon } from '@radix-ui/react-icons';
 import { useDropzone } from 'react-dropzone';
 import { styled } from '../../stitches.config';
@@ -25,7 +25,6 @@ interface CoverImageProps {
 
 export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
   const [loadingSave, setLoadingSave] = useState(false);
-  const [draggingOver, setIsDraggingOver] = useState(false);
 
   const handleRemoveCoverImage = () => {
     setStoryFile({ ...story, coverImage: undefined });
@@ -51,24 +50,16 @@ export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
         contentType: blob.type,
       });
 
-      setIsDraggingOver(false);
       setLoadingSave(false);
       setStoryFile({ ...story, coverImage: coverImageUrl });
     },
     [story]
   );
-  const { getRootProps, getInputProps, fileRejections } = useDropzone({
-    onDrop,
-    accept: 'image/jpeg,image/png',
-    onDragEnter: () => setIsDraggingOver(true),
-    onDragLeave: () => setIsDraggingOver(false),
-  });
-
-  useEffect(() => {
-    if (fileRejections.length > 0) {
-      setIsDraggingOver(false);
-    }
-  }, [fileRejections]);
+  const { getRootProps, getInputProps, fileRejections, isDragActive } =
+    useDropzone({
+      onDrop,
+      accept: 'image/jpeg,image/png',
+    });
 
   return (
     <>
@@ -79,16 +70,16 @@ export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
             variant="ghostMuted"
             css={{
               gap: '$1',
-              flexGrow: draggingOver ? 1 : 0.0001,
-              outline: draggingOver ? '2px dashed $colors$gray7' : 'none',
+              flexGrow: isDragActive ? 1 : 0.0001,
+              outline: isDragActive ? '2px dashed $colors$gray7' : 'none',
               outlineOffset: '2px',
               transition: 'flex-grow .3s ease',
             }}
             type="submit"
           >
-            {!draggingOver && <CameraIcon />}
-            {draggingOver ? `Drop your cover image here` : `Add cover image`}
-            {draggingOver && <HandIcon />}
+            {!isDragActive && <CameraIcon />}
+            {isDragActive ? `Drop your cover image here` : `Add cover image`}
+            {isDragActive && <HandIcon />}
           </Button>
         </Box>
       ) : (

--- a/sigle/src/modules/editor/CoverImage.tsx
+++ b/sigle/src/modules/editor/CoverImage.tsx
@@ -2,15 +2,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { CameraIcon, HandIcon, TrashIcon } from '@radix-ui/react-icons';
 import { useDropzone } from 'react-dropzone';
 import { styled } from '../../stitches.config';
-import { Box, Button, Flex, IconButton } from '../../ui';
+import { Box, Button, IconButton } from '../../ui';
 import { resizeImage } from '../../utils/image';
 import { Story } from '../../types';
 import { storage } from '../../utils/blockstack';
 import { ErrorMessage } from '../../ui/ErrorMessage';
-
-const StyledInput = styled('input', {
-  height: '100%',
-});
 
 const StyledImage = styled('img', {
   variants: {
@@ -78,12 +74,7 @@ export const CoverImage = ({ story, setStoryFile }: CoverImageProps) => {
     <>
       {!story.coverImage ? (
         <Box css={{ py: '$5', mb: '-$5', display: 'flex' }} {...getRootProps()}>
-          <StyledInput
-            css={{
-              backgroundColor: '$gray7',
-            }}
-            {...getInputProps()}
-          />
+          <input {...getInputProps()} />
           <Button
             variant="ghostMuted"
             css={{

--- a/sigle/src/ui/Button.ts
+++ b/sigle/src/ui/Button.ts
@@ -59,6 +59,10 @@ export const Button = styled('button', {
         boxShadow: 'none',
       },
       subtle: {},
+      ghostMuted: {
+        backgroundColor: 'transparent',
+        boxShadow: 'none',
+      },
     },
   },
   compoundVariants: [
@@ -73,6 +77,22 @@ export const Button = styled('button', {
         },
         '&:active': {
           backgroundColor: '$gray5',
+        },
+      },
+    },
+    {
+      color: 'gray',
+      variant: 'ghostMuted',
+      css: {
+        backgroundColor: 'transparent',
+        color: '$gray9',
+        '&:hover': {
+          backgroundColor: '$gray4',
+          color: '$gray11',
+        },
+        '&:active': {
+          backgroundColor: '$gray5',
+          color: '$gray11',
         },
       },
     },

--- a/sigle/src/ui/ErrorMessage.tsx
+++ b/sigle/src/ui/ErrorMessage.tsx
@@ -24,7 +24,7 @@ export const ErrorMessage = ({ children, ...props }: ErrorProps) => {
       }}
     >
       <CrossCircledIcon />
-      <Typography css={{ color: '$red11' }} size="subheading">
+      <Typography css={{ color: '$red11', m: 0 }} size="subheading">
         {children}
       </Typography>
     </Flex>


### PR DESCRIPTION
- Improves user experience when dragging and dropping an image on the cover image trigger.

Closes #654 