### PR TITLE
fix: no box shadow on floating menu

### DIFF
--- a/.changeset/hot-wombats-peel.md
+++ b/.changeset/hot-wombats-peel.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix missing box shadow for floating menu on light mode.

--- a/sigle/src/modules/editor/TipTapEditor.tsx
+++ b/sigle/src/modules/editor/TipTapEditor.tsx
@@ -88,6 +88,8 @@ const globalStylesCustomEditor = globalCss({
     backgroundColor: '$gray1',
     br: '$3',
     minWidth: '280px',
+    boxShadow:
+      '0px 8px 20px rgba(8, 8, 8, 0.09), 0px 10px 18px rgba(8, 8, 8, 0.06), 0px 5px 14px rgba(8, 8, 8, 0.05), 0px 3px 8px rgba(8, 8, 8, 0.05), 0px 1px 5px rgba(8, 8, 8, 0.04), 0px 1px 2px rgba(8, 8, 8, 0.03), 0px 0.2px 1px rgba(8, 8, 8, 0.02)',
 
     [`.${darkTheme} &`]: {
       boxShadow:


### PR DESCRIPTION
This pr fixes the issue with missing box shadow for floating menu on light mode.