### PR TITLE
fix: plain text node not activating on mobile floating menu

### DIFF
--- a/.changeset/funny-chairs-bathe.md
+++ b/.changeset/funny-chairs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix Plain Text node not activating on mobile.

--- a/sigle/src/modules/editor/extensions/SlashCommand/commands.tsx
+++ b/sigle/src/modules/editor/extensions/SlashCommand/commands.tsx
@@ -25,10 +25,11 @@ export const slashCommands = ({
     description: 'Normal paragraph style',
     command: ({ editor, range }) => {
       if (!range) {
+        editor.chain().focus().setParagraph().run();
         return;
       }
 
-      editor.chain().focus().deleteRange(range).setNode('paragraph').run();
+      editor.chain().focus().deleteRange(range).setParagraph().run();
     },
   },
   {


### PR DESCRIPTION
Fixes #696 