### PR TITLE
feat: add fallback og image when sharing profile page

### DIFF
--- a/.changeset/thin-needles-camp.md
+++ b/.changeset/thin-needles-camp.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Add boring avatar as a fallback option when sharing a profile page without a PFP set by the user.

--- a/.changeset/thin-needles-camp.md
+++ b/.changeset/thin-needles-camp.md
@@ -3,3 +3,4 @@
 ---
 
 Add boring avatar as a fallback option when sharing a profile page without a PFP set by the user.
+Encode image URL to display images with special characters correctly.

--- a/sigle/src/modules/publicHome/components/PublicHome.tsx
+++ b/sigle/src/modules/publicHome/components/PublicHome.tsx
@@ -166,6 +166,7 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
   const seoDescription =
     settings.siteDescription?.substring(0, 300) ||
     `Read stories from ${siteName} on Sigle, decentralised and open-source platform for Web3 writers`;
+
   const seoImage = settings.siteLogo;
 
   const Layout =
@@ -185,6 +186,23 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
     );
   };
 
+  const encodeImageUrl = (url: string | undefined) => {
+    if (!url) {
+      return;
+    }
+
+    // encode part of url that includes file name which may contain special characters
+    const split = 'settings/';
+    const splitUrl = url.split(split);
+    const encodedUrl =
+      splitUrl &&
+      splitUrl[0] +
+        split +
+        encodeURI(splitUrl[1]).replace('(', '%28').replace(')', '%29');
+
+    return encodedUrl;
+  };
+
   return (
     <React.Fragment>
       <NextSeo
@@ -197,7 +215,7 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
           description: seoDescription,
           images: [
             {
-              url: seoImage || generateAvatar(userAddress),
+              url: encodeImageUrl(seoImage) || generateAvatar(userAddress),
             },
           ],
         }}

--- a/sigle/src/modules/publicHome/components/PublicHome.tsx
+++ b/sigle/src/modules/publicHome/components/PublicHome.tsx
@@ -167,7 +167,9 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
     settings.siteDescription?.substring(0, 300) ||
     `Read stories from ${siteName} on Sigle, decentralised and open-source platform for Web3 writers`;
 
-  const seoImage = settings.siteLogo;
+  const seoImage =
+    settings.siteLogo &&
+    encodeURI(settings.siteLogo).replace('(', '%28').replace(')', '%29');
 
   const Layout =
     userInfo.username !== user?.username ? React.Fragment : DashboardLayout;
@@ -186,23 +188,6 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
     );
   };
 
-  const encodeImageUrl = (url: string | undefined) => {
-    if (!url) {
-      return;
-    }
-
-    // encode part of url that includes file name which may contain special characters
-    const split = 'settings/';
-    const splitUrl = url.split(split);
-    const encodedUrl =
-      splitUrl &&
-      splitUrl[0] +
-        split +
-        encodeURI(splitUrl[1]).replace('(', '%28').replace(')', '%29');
-
-    return encodedUrl;
-  };
-
   return (
     <React.Fragment>
       <NextSeo
@@ -215,7 +200,7 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
           description: seoDescription,
           images: [
             {
-              url: encodeImageUrl(seoImage) || generateAvatar(userAddress),
+              url: seoImage || generateAvatar(userAddress),
             },
           ],
         }}

--- a/sigle/src/modules/publicHome/components/PublicHome.tsx
+++ b/sigle/src/modules/publicHome/components/PublicHome.tsx
@@ -156,6 +156,9 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
     stories.splice(featuredStoryIndex, 1);
   }
 
+  const userAddress =
+    user?.profile.stxAddress.mainnet || user?.profile.stxAddress;
+
   const siteName = settings.siteName || userInfo.username;
 
   const seoUrl = `${sigleConfig.appUrl}/${userInfo.username}`;
@@ -194,7 +197,7 @@ export const PublicHome = ({ file, settings, userInfo }: PublicHomeProps) => {
           description: seoDescription,
           images: [
             {
-              url: seoImage || `${sigleConfig.appUrl}/static/icon-192x192.png`,
+              url: seoImage || generateAvatar(userAddress),
             },
           ],
         }}


### PR DESCRIPTION
- Adds boring avatar fallback if the user has no profile image
- Encodes image url 

Tool used to verify og meta image is working: https://www.opengraph.xyz/

Closes #684 