### PR TITLE
fix: fix cover image not showing in list

### DIFF
--- a/.changeset/kind-impalas-hammer.md
+++ b/.changeset/kind-impalas-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sigle/app': patch
+---
+
+Fix cover image not showing in story list.

--- a/sigle/src/modules/storyCard/StoryCardImage.tsx
+++ b/sigle/src/modules/storyCard/StoryCardImage.tsx
@@ -47,6 +47,7 @@ const StoryImage = styled('img', {
   height: 58,
   zIndex: -1,
   position: 'relative',
+  maxWidth: 'inherit',
 
   '@md': {
     width: 180,


### PR DESCRIPTION
The story "Cycle #46" is missing the cover image. https://app.sigle.io/friedgerpool.btc