### PR TITLE
feat: always store first post revision

### DIFF
--- a/apps/server/src/jobs/indexer/post/new-post.test.ts
+++ b/apps/server/src/jobs/indexer/post/new-post.test.ts
@@ -1,0 +1,112 @@
+import { MAX_UINT } from "@sigle/sdk";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { sigleClient } from "@/lib/sigle";
+import { createTestDatabase, type TestDatabase } from "@/test/database";
+import { createTestUser } from "@/test/helpers";
+import { executeNewPostJob } from "./new-post";
+
+vi.mock<typeof import("@/lib/consola")>(
+  import("@/lib/consola"),
+  () =>
+    ({
+      consola: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    }) as unknown as typeof import("@/lib/consola"),
+);
+
+const mockFetch = vi.spyOn(globalThis, "fetch");
+
+describe(executeNewPostJob, () => {
+  let testDb: TestDatabase | undefined = undefined;
+  const userId = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase();
+  });
+
+  beforeEach(async () => {
+    if (testDb) {
+      await testDb.cleanup();
+    }
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (testDb) {
+      await testDb.close();
+    }
+  });
+
+  it("creates a new post and creates its initial PostRevision", async () => {
+    await createTestUser({ id: userId });
+
+    const baseTokenUri = "ar://tx-metadata-id";
+    const postId = "post-123";
+    const txId = "tx-456";
+
+    const { contract } = sigleClient.generatePostContract({
+      metadata: baseTokenUri,
+      collectInfo: {
+        amount: 1000n,
+        maxSupply: BigInt(MAX_UINT),
+      },
+    });
+
+    const mockPostMetadata = {
+      $schema: "https://json-schemas.sigle.io/posts/1.0.0.json",
+      content: {
+        id: postId,
+        title: "New Post Title",
+        content: "New Post Content",
+        tags: ["news"],
+        attributes: [{ key: "excerpt", value: "Excerpt", type: "String" }],
+      },
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockPostMetadata,
+    } as Response);
+
+    await executeNewPostJob({
+      address: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.post-123",
+      txId,
+      blockHeight: 120,
+      version: "1.0.0",
+      contract,
+      sender: userId,
+      createdAt: new Date("2026-01-01"),
+      isStreamingBlocks: false,
+    });
+
+    const post = await testDb?.db.post.findUnique({
+      where: { id: postId },
+    });
+    expect(post).toMatchObject({
+      id: postId,
+      txId,
+      title: "New Post Title",
+    });
+
+    const revisions = await testDb?.db.postRevision.findMany({
+      where: { postId },
+    });
+    expect(revisions).toHaveLength(1);
+    expect(revisions?.[0]).toMatchObject({
+      postId,
+      txId,
+    });
+  });
+});

--- a/apps/server/src/jobs/indexer/post/new-post.test.ts
+++ b/apps/server/src/jobs/indexer/post/new-post.test.ts
@@ -44,6 +44,7 @@ describe(executeNewPostJob, () => {
   });
 
   afterAll(async () => {
+    mockFetch.mockRestore();
     if (testDb) {
       await testDb.close();
     }

--- a/apps/server/src/jobs/indexer/post/new-post.ts
+++ b/apps/server/src/jobs/indexer/post/new-post.ts
@@ -205,6 +205,21 @@ export const executeNewPostJob = async (
       },
     });
 
+    await tx.postRevision.upsert({
+      where: {
+        postId_txId: {
+          postId: metadata.id,
+          txId: data.txId,
+        },
+      },
+      update: {},
+      create: {
+        postId: metadata.id,
+        txId: data.txId,
+        createdAt: new Date(data.createdAt),
+      },
+    });
+
     if (metadata.coverImage) {
       await tx.post.update({
         where: {

--- a/apps/server/src/jobs/indexer/post/publish-post.ts
+++ b/apps/server/src/jobs/indexer/post/publish-post.ts
@@ -73,6 +73,7 @@ export const executePublishPostJob = async (
       select: {
         id: true,
         txId: true,
+        createdAt: true,
         coverImageId: true,
       },
       where: {
@@ -110,6 +111,7 @@ export const executePublishPostJob = async (
         create: {
           postId: targetPostId,
           txId: post.txId,
+          createdAt: post.createdAt,
         },
       });
     }

--- a/apps/server/src/jobs/indexer/post/publish-post.ts
+++ b/apps/server/src/jobs/indexer/post/publish-post.ts
@@ -98,6 +98,22 @@ export const executePublishPostJob = async (
 
     const isNewTx = !post || post.txId !== data.txId;
 
+    if (post && isNewTx) {
+      await tx.postRevision.upsert({
+        where: {
+          postId_txId: {
+            postId: targetPostId,
+            txId: post.txId,
+          },
+        },
+        update: {},
+        create: {
+          postId: targetPostId,
+          txId: post.txId,
+        },
+      });
+    }
+
     const updatedPost = post
       ? await tx.post.update({
           where: {

--- a/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.test.ts
+++ b/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.test.ts
@@ -167,13 +167,6 @@ describe("api/protected/drafts/[draftId]/upload-metadata.post", () => {
       content: "Original content",
     });
 
-    await testDb.db.postRevision.create({
-      data: {
-        postId: originalPost.id,
-        txId: originalPost.txId,
-      },
-    });
-
     mockGetRouterParam.mockReturnValue(originalPost.id);
 
     const editedMetadata = {

--- a/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
+++ b/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
@@ -217,6 +217,7 @@ export default defineEventHandler(async (event) => {
       select: {
         id: true,
         txId: true,
+        createdAt: true,
       },
       where: {
         id: targetPostId,
@@ -235,6 +236,7 @@ export default defineEventHandler(async (event) => {
         create: {
           postId: targetPostId,
           txId: existingPost.txId,
+          createdAt: existingPost.createdAt,
         },
       });
     }

--- a/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
+++ b/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
@@ -216,11 +216,28 @@ export default defineEventHandler(async (event) => {
     const existingPost = await tx.post.findUnique({
       select: {
         id: true,
+        txId: true,
       },
       where: {
         id: targetPostId,
       },
     });
+
+    if (existingPost && existingPost.txId !== id) {
+      await tx.postRevision.upsert({
+        where: {
+          postId_txId: {
+            postId: targetPostId,
+            txId: existingPost.txId,
+          },
+        },
+        update: {},
+        create: {
+          postId: targetPostId,
+          txId: existingPost.txId,
+        },
+      });
+    }
 
     const sharedMetadata = {
       metadataUri: `ar://${id}`,

--- a/apps/server/src/test/helpers.ts
+++ b/apps/server/src/test/helpers.ts
@@ -67,7 +67,7 @@ export async function createTestPost(
 ): Promise<Post> {
   const now = new Date();
 
-  return prisma.post.create({
+  const post = await prisma.post.create({
     data: {
       id: options.id ?? `post-${Date.now()}`,
       version: options.version ?? "1.0.0",
@@ -83,6 +83,23 @@ export async function createTestPost(
       userId: options.userId,
     },
   });
+
+  await prisma.postRevision.upsert({
+    where: {
+      postId_txId: {
+        postId: post.id,
+        txId: post.txId,
+      },
+    },
+    update: {},
+    create: {
+      postId: post.id,
+      txId: post.txId,
+      createdAt: now,
+    },
+  });
+
+  return post;
 }
 
 interface CreateTestDraftOptions {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revision tracking by creating/upserting revision records when new posts are indexed and when posts are published across transactions.
  * Ensured revision history is retained during metadata edits, including pre-populating the previous transaction’s revision when needed.
* **Tests**
  * Added coverage for the new-post indexing flow to verify post and revision persistence.
  * Updated draft metadata upload tests to reflect the improved revision-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->