### PR TITLE
feat: save arweave L1 tx info

### DIFF
--- a/apps/server/prisma/migrations/20260803174500_add_arweave_l1_tx_id/migration.sql
+++ b/apps/server/prisma/migrations/20260803174500_add_arweave_l1_tx_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "post" ADD COLUMN "arweave_l1_tx_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "post_revision" ADD COLUMN "arweave_l1_tx_id" TEXT;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -148,11 +148,12 @@ model Draft {
 }
 
 model Post {
-  id          String @id @map("id")
-  version     String @map("version")
-  txId        String @unique @map("tx_id")
-  blockHeight Int    @map("block_height")
-  metadataUri String @map("metadata_uri")
+  id            String  @id @map("id")
+  version       String  @map("version")
+  txId          String  @unique @map("tx_id")
+  arweaveL1TxId String? @map("arweave_l1_tx_id")
+  blockHeight   Int     @map("block_height")
+  metadataUri   String  @map("metadata_uri")
 
   // Metadata fields
   title           String      @map("title")
@@ -186,9 +187,10 @@ model PostRevision {
 
   createdAt DateTime @default(now()) @map("created_at")
 
-  postId String @map("post_id")
-  post   Post   @relation(fields: [postId], references: [id], onDelete: Cascade)
-  txId   String @map("tx_id")
+  postId        String  @map("post_id")
+  post          Post    @relation(fields: [postId], references: [id], onDelete: Cascade)
+  txId          String  @map("tx_id")
+  arweaveL1TxId String? @map("arweave_l1_tx_id")
 
   @@unique([postId, txId])
   @@index([postId])

--- a/apps/server/src/jobs/indexer/post/index-posts.test.ts
+++ b/apps/server/src/jobs/indexer/post/index-posts.test.ts
@@ -133,11 +133,69 @@ describe("executeIndexerIndexPostsJob", () => {
       action: "indexer-publish-post",
       data: {
         txId: "arweave-tx-1",
+        arweaveL1TxId: undefined,
         rootTxId: undefined,
         blockHeight: 12345,
         author: userId,
         uri: "ar://arweave-tx-1",
         createdAt: new Date(1672531199 * 1000),
+      },
+    });
+  });
+
+  it("extracts bundledIn id as arweaveL1TxId when present", async () => {
+    await createTestUser({ id: userId });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          transactions: {
+            edges: [
+              {
+                node: {
+                  id: "arweave-tx-bundled",
+                  bundledIn: {
+                    id: "l1-arweave-tx-123",
+                  },
+                  block: {
+                    height: 12347,
+                    timestamp: 1672531201,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    } as Response);
+
+    const mockGetMetadata = getMetadataFromUri as any;
+    mockGetMetadata.mockResolvedValue(
+      Result.ok({
+        version: "v1",
+        id: "post-id-bundled",
+        title: "Bundled Post",
+        content: "Hello world",
+        excerpt: "Hello",
+        recoveredAddress: userId,
+        signature: "sig-bundled",
+      }),
+    );
+
+    const result = await executeIndexerIndexPostsJob({});
+
+    expect(result.toProcess).toBe(1);
+    expect(mockEmit).toHaveBeenCalledWith({
+      action: "indexer-publish-post",
+      data: {
+        txId: "arweave-tx-bundled",
+        arweaveL1TxId: "l1-arweave-tx-123",
+        rootTxId: undefined,
+        blockHeight: 12347,
+        author: userId,
+        uri: "ar://arweave-tx-bundled",
+        createdAt: new Date(1672531201 * 1000),
       },
     });
   });
@@ -192,6 +250,7 @@ describe("executeIndexerIndexPostsJob", () => {
       action: "indexer-publish-post",
       data: {
         txId: "arweave-tx-2",
+        arweaveL1TxId: undefined,
         rootTxId: "original-tx-id",
         blockHeight: 12346,
         author: userId,

--- a/apps/server/src/jobs/indexer/post/index-posts.ts
+++ b/apps/server/src/jobs/indexer/post/index-posts.ts
@@ -21,6 +21,9 @@ export interface ArweavePostEdge {
   cursor: string;
   node: {
     id: string;
+    bundledIn?: {
+      id: string;
+    } | null;
     tags?: Array<{
       name: string;
       value: string;
@@ -64,6 +67,9 @@ export async function fetchArweavePostTransactions({
           cursor
           node {
             id
+            bundledIn {
+              id
+            }
             tags {
               name
               value
@@ -226,11 +232,13 @@ export const executeIndexerIndexPostsJob = async (
 
       const rootTxTag = edge.node.tags?.find((t) => t.name === "Root-TX");
       const rootTxId = rootTxTag?.value;
+      const arweaveL1TxId = edge.node.bundledIn?.id;
 
       await indexerJob.emit({
         action: "indexer-publish-post",
         data: {
           txId,
+          arweaveL1TxId,
           rootTxId,
           blockHeight,
           author: metadata.recoveredAddress,

--- a/apps/server/src/jobs/indexer/post/publish-post.test.ts
+++ b/apps/server/src/jobs/indexer/post/publish-post.test.ts
@@ -75,6 +75,7 @@ describe("executePublishPostJob", () => {
 
     await executePublishPostJob({
       txId: "tx-1",
+      arweaveL1TxId: "l1-tx-1",
       blockHeight: 100,
       author: userId,
       uri: "ar://tx-1",
@@ -88,6 +89,7 @@ describe("executePublishPostJob", () => {
     expect(post).toMatchObject({
       id: "tx-1",
       txId: "tx-1",
+      arweaveL1TxId: "l1-tx-1",
       title: "Initial Post Title",
       revisionsCount: 1,
     });
@@ -99,6 +101,7 @@ describe("executePublishPostJob", () => {
     expect(revisions?.[0]).toMatchObject({
       postId: "tx-1",
       txId: "tx-1",
+      arweaveL1TxId: "l1-tx-1",
     });
   });
 

--- a/apps/server/src/jobs/indexer/post/publish-post.ts
+++ b/apps/server/src/jobs/indexer/post/publish-post.ts
@@ -9,6 +9,7 @@ export const indexerPublishPostSchema = z.object({
   action: z.literal("indexer-publish-post"),
   data: z.object({
     txId: z.string(),
+    arweaveL1TxId: z.string().optional(),
     rootTxId: z.string().optional(),
     blockHeight: z.number(),
     author: z.string(),
@@ -123,6 +124,7 @@ export const executePublishPostJob = async (
           },
           data: {
             txId: data.txId,
+            arweaveL1TxId: data.arweaveL1TxId ?? null,
             version: metadata.version,
             blockHeight: data.blockHeight,
             signature: metadata.signature,
@@ -149,6 +151,7 @@ export const executePublishPostJob = async (
           data: {
             id: targetPostId,
             txId: data.txId,
+            arweaveL1TxId: data.arweaveL1TxId ?? null,
             version: metadata.version,
             blockHeight: data.blockHeight,
             signature: metadata.signature,
@@ -175,10 +178,13 @@ export const executePublishPostJob = async (
           txId: data.txId,
         },
       },
-      update: {},
+      update: {
+        ...(data.arweaveL1TxId ? { arweaveL1TxId: data.arweaveL1TxId } : {}),
+      },
       create: {
         postId: targetPostId,
         txId: data.txId,
+        arweaveL1TxId: data.arweaveL1TxId ?? null,
         createdAt: new Date(data.createdAt),
       },
     });

--- a/apps/server/src/lib/prisma.ts
+++ b/apps/server/src/lib/prisma.ts
@@ -50,6 +50,7 @@ export const SELECT_PUBLIC_POST_FIELDS = {
   tags: true,
   canonicalUri: true,
   txId: true,
+  arweaveL1TxId: true,
   blockHeight: true,
   metadataUri: true,
   revisionsCount: true,

--- a/apps/server/src/routes/health.get.ts
+++ b/apps/server/src/routes/health.get.ts
@@ -184,6 +184,9 @@ defineRouteMeta({
               txId: {
                 type: "string",
               },
+              arweaveL1TxId: {
+                type: "string",
+              },
               blockHeight: {
                 type: "number",
               },

--- a/apps/sigle/src/components/Post/ProvenanceCard.tsx
+++ b/apps/sigle/src/components/Post/ProvenanceCard.tsx
@@ -168,6 +168,58 @@ export const PostProvenanceCard = ({ post }: PostProvenanceCardProps) => {
                   </div>
                 </div>
 
+                {post.arweaveL1TxId ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                      <IconDatabase size={14} />
+                      <span>Arweave L1 Block Proof</span>
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg bg-secondary/50 px-3 py-2.5">
+                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <span className="text-xs text-muted-foreground">
+                          L1 Transaction ID
+                        </span>
+                        {/* oxlint-disable-next-line better-tailwindcss/enforce-consistent-line-wrapping */}
+                        <span className="truncate font-mono text-sm text-foreground">
+                          {truncateId(post.arweaveL1TxId, 12, 8)}
+                        </span>
+                      </div>
+                      <div className="ml-3 flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="size-8 p-0 text-muted-foreground hover:text-foreground"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            copyToClipboard(post.arweaveL1TxId!);
+                          }}
+                        >
+                          <IconCopy size={14} />
+                        </Button>
+                        <Button
+                          nativeButton={false}
+                          variant="ghost"
+                          size="sm"
+                          className="size-8 p-0 text-muted-foreground hover:text-foreground"
+                          render={
+                            <a
+                              href={`https://viewblock.io/arweave/tx/${post.arweaveL1TxId}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          }
+                        >
+                          <IconExternalLink size={14} />
+                          <span className="sr-only">
+                            View on Viewblock (Arweave L1)
+                          </span>
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
                 {/* Stacks Transaction */}
                 <div className="space-y-2">
                   <div className="flex items-center gap-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">

--- a/packages/sdk/src/__generated__/sigle-api-openapi.ts
+++ b/packages/sdk/src/__generated__/sigle-api-openapi.ts
@@ -1270,6 +1270,7 @@ export interface components {
       tags?: string[];
       canonicalUri?: string;
       txId: string;
+      arweaveL1TxId?: string;
       blockHeight: number;
       revisionsCount?: number;
       collectorsCount?: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arweave L1 transaction tracking for posts and post revisions.
  * Provenance details now display the Arweave transaction ID when available.
  * Added quick-copy support and a link to view the transaction on Arweave.
  * Published post data and API responses now include the optional transaction ID.
* **Tests**
  * Added coverage for posts with and without Arweave bundling metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->