### PR TITLE
chore: change arweaveUploadFile to accept buffer

### DIFF
--- a/apps/server/src/lib/arweave.ts
+++ b/apps/server/src/lib/arweave.ts
@@ -9,6 +9,8 @@ const turboClient = TurboFactory.authenticated({
   token: "solana",
 });
 
+export type ArweaveContentType = "application/json";
+
 interface ArweaveTag {
   name: string;
   value: string;
@@ -24,21 +26,22 @@ export class ArweaveUploadFailedError extends TaggedError(
 export const arweaveUploadFile = async (
   event: H3Event,
   {
-    metadata,
+    file,
+    contentType,
     tags = [],
   }: {
-    metadata: object;
+    file: Buffer;
+    contentType: ArweaveContentType;
     tags?: ArweaveTag[];
   },
 ): Promise<Result<{ id: string }, ArweaveUploadFailedError>> => {
-  const file = Buffer.from(JSON.stringify(metadata));
   const fileSize = file.byteLength;
   const cid = await createCIDv1FromBuffer(file);
 
   const arweaveTags: ArweaveTag[] = [
     {
       name: "content-type",
-      value: "application/json",
+      value: contentType,
     },
     {
       name: "App-Name",
@@ -64,7 +67,8 @@ export const arweaveUploadFile = async (
       const sentryId = event.context.$sentry.captureException(error, {
         level: "error",
         extra: {
-          metadata,
+          contentType,
+          tags: arweaveTags,
         },
       });
       return new ArweaveUploadFailedError({ cause: error, sentryId });

--- a/apps/server/src/lib/arweave.ts
+++ b/apps/server/src/lib/arweave.ts
@@ -40,7 +40,7 @@ export const arweaveUploadFile = async (
 
   const arweaveTags: ArweaveTag[] = [
     {
-      name: "content-type",
+      name: "Content-Type",
       value: contentType,
     },
     {

--- a/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.test.ts
+++ b/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.test.ts
@@ -137,7 +137,8 @@ describe("api/protected/drafts/[draftId]/upload-metadata.post", () => {
       arweaveId: "arweave-tx-draft",
     });
     expect(arweaveUploadFile).toHaveBeenCalledWith(mockEvent, {
-      metadata: mockMetadata,
+      file: Buffer.from(JSON.stringify(mockMetadata)),
+      contentType: "application/json",
       tags: [{ name: "Author", value: userId }],
     });
 
@@ -216,7 +217,8 @@ describe("api/protected/drafts/[draftId]/upload-metadata.post", () => {
 
     // Verify Root-TX tag was included
     expect(arweaveUploadFile).toHaveBeenCalledWith(mockEvent, {
-      metadata: editedMetadata,
+      file: Buffer.from(JSON.stringify(editedMetadata)),
+      contentType: "application/json",
       tags: [
         { name: "Author", value: userId },
         { name: "Root-TX", value: originalPost.id },

--- a/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
+++ b/apps/server/src/routes/api/protected/drafts/[draftId]/upload-metadata.post.ts
@@ -178,7 +178,8 @@ export default defineEventHandler(async (event) => {
   }
 
   const uploadResult = await arweaveUploadFile(event, {
-    metadata: parsedMetadata.data,
+    file: Buffer.from(JSON.stringify(parsedMetadata.data)),
+    contentType: "application/json",
     tags,
   });
 

--- a/apps/server/src/routes/api/protected/user/profile/upload-metadata.post.ts
+++ b/apps/server/src/routes/api/protected/user/profile/upload-metadata.post.ts
@@ -70,7 +70,8 @@ export default defineEventHandler(async (event) => {
   }
 
   const uploadResult = await arweaveUploadFile(event, {
-    metadata: parsedMetadata.data,
+    file: Buffer.from(JSON.stringify(parsedMetadata.data)),
+    contentType: "application/json",
   });
 
   if (uploadResult.isErr()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Metadata uploads for drafts and user profiles are now stored as properly formatted JSON files.
  * Uploaded metadata is labeled with the correct content type, improving compatibility when retrieved or displayed.
  * File-based uploads now provide more consistent handling across supported metadata upload flows.

* **Bug Fixes**
  * Corrected metadata upload processing to prevent format and content-type mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->