### PR TITLE
feat: index arweave L1 tx ids

### DIFF
--- a/apps/server/src/jobs/indexer/index.ts
+++ b/apps/server/src/jobs/indexer/index.ts
@@ -35,6 +35,10 @@ import {
   indexerSetBaseTokenUriSchema,
 } from "./post/set-base-token-uri";
 import {
+  executeIndexerSyncArweaveL1TxIdsJob,
+  indexerSyncArweaveL1TxIdsSchema,
+} from "./post/sync-arweave-l1-tx-ids";
+import {
   executeIndexerIndexProfilesJob,
   indexerIndexProfilesSchema,
 } from "./profile/index-profiles";
@@ -58,6 +62,7 @@ export const indexerJob = defineJob("indexer")
       indexerIndexPostsSchema,
       indexerIndexProfilesSchema,
       indexerPublishPostSchema,
+      indexerSyncArweaveL1TxIdsSchema,
     ]),
   )
   .options({
@@ -94,6 +99,9 @@ export const indexerJob = defineJob("indexer")
         break;
       case "indexer-publish-post":
         await executePublishPostJob(job.data.data);
+        break;
+      case "indexer-sync-arweave-l1-tx-ids":
+        await executeIndexerSyncArweaveL1TxIdsJob(job.data.data);
         break;
       case "indexer-index-profiles":
         await executeIndexerIndexProfilesJob(job.data.data);

--- a/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.test.ts
+++ b/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.test.ts
@@ -171,5 +171,79 @@ describe("sync-arweave-l1-tx-ids", () => {
 
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it("includes revision in batch when 100 unmapped posts and 1 mappable revision exist", async () => {
+      await createTestUser({ id: userId });
+
+      const postCreates = [];
+      for (let i = 0; i < 100; i++) {
+        postCreates.push({
+          id: `unmapped-post-${i}`,
+          txId: `unmapped-post-tx-${i}`,
+          version: "1.0.0",
+          blockHeight: 100,
+          title: `Post ${i}`,
+          content: "Content",
+          excerpt: "Excerpt",
+          metadataUri: `ar://unmapped-post-tx-${i}`,
+          userId,
+        });
+      }
+      await testDb?.db.post.createMany({ data: postCreates });
+
+      const hostPost = await createTestPost({
+        id: "host-post-for-revision",
+        txId: "host-post-tx",
+        userId,
+      });
+      await testDb?.db.post.update({
+        where: { id: hostPost.id },
+        data: { arweaveL1TxId: "host-l1-id" },
+      });
+
+      const revisionTxId = "unmapped-revision-tx-1";
+      await testDb?.db.postRevision.create({
+        data: {
+          postId: hostPost.id,
+          txId: revisionTxId,
+        },
+      });
+
+      const mockFetch = vi.fn((_url, options) => {
+        const bodyStr = (options as RequestInit | undefined)?.body as string;
+        expect(bodyStr).toContain(revisionTxId);
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                transactions: {
+                  edges: [
+                    {
+                      node: {
+                        id: revisionTxId,
+                        bundledIn: { id: "l1-revision-tx-1" },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await executeIndexerSyncArweaveL1TxIdsJob({});
+
+      const updatedRevision = await testDb?.db.postRevision.findFirst({
+        where: { txId: revisionTxId },
+      });
+      expect(updatedRevision?.arweaveL1TxId).toBe("l1-revision-tx-1");
+    });
   });
 });

--- a/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.test.ts
+++ b/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.test.ts
@@ -1,0 +1,175 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { createTestDatabase, type TestDatabase } from "@/test/database";
+import { createTestPost, createTestUser } from "@/test/helpers";
+
+vi.mock<typeof import("@/lib/consola")>(
+  import("@/lib/consola"),
+  () =>
+    ({
+      consola: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    }) as unknown as typeof import("@/lib/consola"),
+);
+
+const { fetchArweaveL1TxIds, executeIndexerSyncArweaveL1TxIdsJob } =
+  await import("./sync-arweave-l1-tx-ids");
+
+describe("sync-arweave-l1-tx-ids", () => {
+  let testDb: TestDatabase | undefined = undefined;
+  const userId = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase();
+  });
+
+  beforeEach(async () => {
+    if (testDb) {
+      await testDb.cleanup();
+    }
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (testDb) {
+      await testDb.close();
+    }
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchArweaveL1TxIds", () => {
+    it("returns empty mapping when input txIds array is empty", async () => {
+      const result = await fetchArweaveL1TxIds([]);
+      expect(result.unwrap()).toStrictEqual({});
+    });
+
+    it("fetches and maps bundledIn.id from GraphQL response", async () => {
+      const mockFetch = vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                transactions: {
+                  edges: [
+                    {
+                      node: {
+                        id: "arweave-tx-1",
+                        bundledIn: { id: "l1-tx-1" },
+                      },
+                    },
+                    {
+                      node: {
+                        id: "arweave-tx-2",
+                        bundledIn: null,
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ),
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchArweaveL1TxIds([
+        "arweave-tx-1",
+        "arweave-tx-2",
+      ]);
+      expect(result.unwrap()).toStrictEqual({
+        "arweave-tx-1": "l1-tx-1",
+      });
+    });
+  });
+
+  describe("executeIndexerSyncArweaveL1TxIdsJob", () => {
+    it("updates Post and PostRevision when L1 tx ID is found", async () => {
+      await createTestUser({ id: userId });
+
+      const post1 = await createTestPost({
+        id: "post-1",
+        txId: "tx-arweave-1",
+        userId,
+      });
+
+      const mockFetch = vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                transactions: {
+                  edges: [
+                    {
+                      node: {
+                        id: "tx-arweave-1",
+                        bundledIn: { id: "l1-bundle-tx-1" },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ),
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await executeIndexerSyncArweaveL1TxIdsJob({});
+
+      const updatedPost = await testDb?.db.post.findUnique({
+        where: { id: post1.id },
+      });
+      expect(updatedPost?.arweaveL1TxId).toBe("l1-bundle-tx-1");
+
+      const updatedRevision = await testDb?.db.postRevision.findFirst({
+        where: { postId: post1.id, txId: "tx-arweave-1" },
+      });
+      expect(updatedRevision?.arweaveL1TxId).toBe("l1-bundle-tx-1");
+    });
+
+    it("does nothing when all posts already have arweaveL1TxId", async () => {
+      await createTestUser({ id: userId });
+
+      const post1 = await createTestPost({
+        id: "post-1",
+        txId: "tx-arweave-1",
+        userId,
+      });
+
+      await testDb?.db.post.update({
+        where: { id: post1.id },
+        data: { arweaveL1TxId: "already-set-l1-id" },
+      });
+      await testDb?.db.postRevision.updateMany({
+        where: { postId: post1.id },
+        data: { arweaveL1TxId: "already-set-l1-id" },
+      });
+
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      await executeIndexerSyncArweaveL1TxIdsJob({});
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.ts
+++ b/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.ts
@@ -59,36 +59,44 @@ export async function fetchArweaveL1TxIds(
 
   return Result.tryPromise({
     try: async () => {
-      const response = await fetch(`${env.ARWEAVE_GATEWAY_URL}/graphql`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query }),
-      });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
+      try {
+        const response = await fetch(`${env.ARWEAVE_GATEWAY_URL}/graphql`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ query }),
+          signal: controller.signal,
+        });
 
-      const result = (await response.json()) as ArweaveL1GraphQLResponse;
-      if (result.errors && result.errors.length > 0) {
-        throw new Error(
-          `GraphQL error: ${result.errors.map((e) => e.message).join(", ")}`,
-        );
-      }
-
-      const edges = result.data?.transactions?.edges ?? [];
-      const mapping: Record<string, string> = {};
-
-      for (const edge of edges) {
-        const l1TxId = edge.node.bundledIn?.id;
-        if (l1TxId) {
-          mapping[edge.node.id] = l1TxId;
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
         }
-      }
 
-      return mapping;
+        const result = (await response.json()) as ArweaveL1GraphQLResponse;
+        if (result.errors && result.errors.length > 0) {
+          throw new Error(
+            `GraphQL error: ${result.errors.map((e) => e.message).join(", ")}`,
+          );
+        }
+
+        const edges = result.data?.transactions?.edges ?? [];
+        const mapping: Record<string, string> = {};
+
+        for (const edge of edges) {
+          const l1TxId = edge.node.bundledIn?.id;
+          if (l1TxId) {
+            mapping[edge.node.id] = l1TxId;
+          }
+        }
+
+        return mapping;
+      } finally {
+        clearTimeout(timeoutId);
+      }
     },
     catch: (error) => {
       const errorMessage =
@@ -114,14 +122,19 @@ export const executeIndexerSyncArweaveL1TxIdsJob = async (
   });
 
   const txIdsSet = new Set<string>();
-  for (const p of postsWithoutL1) {
-    txIdsSet.add(p.txId);
-  }
-  for (const r of revisionsWithoutL1) {
-    txIdsSet.add(r.txId);
+  const maxLen = Math.max(postsWithoutL1.length, revisionsWithoutL1.length);
+  for (let i = 0; i < maxLen; i++) {
+    if (i < postsWithoutL1.length) {
+      txIdsSet.add(postsWithoutL1[i].txId);
+      if (txIdsSet.size >= 100) break;
+    }
+    if (i < revisionsWithoutL1.length) {
+      txIdsSet.add(revisionsWithoutL1[i].txId);
+      if (txIdsSet.size >= 100) break;
+    }
   }
 
-  const txIds = Array.from(txIdsSet).slice(0, 100);
+  const txIds = Array.from(txIdsSet);
 
   if (txIds.length === 0) {
     consola.debug("No posts or revisions missing arweaveL1TxId found");

--- a/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.ts
+++ b/apps/server/src/jobs/indexer/post/sync-arweave-l1-tx-ids.ts
@@ -1,0 +1,174 @@
+import { Result, TaggedError } from "better-result";
+import { z } from "zod";
+import { env } from "@/env";
+import { consola } from "@/lib/consola";
+import { prisma } from "@/lib/prisma";
+
+export const indexerSyncArweaveL1TxIdsSchema = z.object({
+  action: z.literal("indexer-sync-arweave-l1-tx-ids"),
+  data: z.object({}),
+});
+
+export class FetchArweaveL1TxIdsFailedError extends TaggedError(
+  "FetchArweaveL1TxIdsFailedError",
+)<{
+  error: string;
+}>() {}
+
+interface ArweaveL1GraphQLResponse {
+  errors?: Array<{ message: string }>;
+  data?: {
+    transactions?: {
+      edges?: Array<{
+        node: {
+          id: string;
+          bundledIn?: {
+            id: string;
+          } | null;
+        };
+      }>;
+    };
+  };
+}
+
+export async function fetchArweaveL1TxIds(
+  txIds: string[],
+): Promise<Result<Record<string, string>, FetchArweaveL1TxIdsFailedError>> {
+  if (txIds.length === 0) {
+    return Result.ok({});
+  }
+
+  const idsJson = JSON.stringify(txIds);
+  const query = `
+    query {
+      transactions(
+        ids: ${idsJson}
+        first: ${txIds.length}
+      ) {
+        edges {
+          node {
+            id
+            bundledIn {
+              id
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  return Result.tryPromise({
+    try: async () => {
+      const response = await fetch(`${env.ARWEAVE_GATEWAY_URL}/graphql`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = (await response.json()) as ArweaveL1GraphQLResponse;
+      if (result.errors && result.errors.length > 0) {
+        throw new Error(
+          `GraphQL error: ${result.errors.map((e) => e.message).join(", ")}`,
+        );
+      }
+
+      const edges = result.data?.transactions?.edges ?? [];
+      const mapping: Record<string, string> = {};
+
+      for (const edge of edges) {
+        const l1TxId = edge.node.bundledIn?.id;
+        if (l1TxId) {
+          mapping[edge.node.id] = l1TxId;
+        }
+      }
+
+      return mapping;
+    },
+    catch: (error) => {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return new FetchArweaveL1TxIdsFailedError({ error: errorMessage });
+    },
+  });
+}
+
+export const executeIndexerSyncArweaveL1TxIdsJob = async (
+  _data: z.TypeOf<typeof indexerSyncArweaveL1TxIdsSchema>["data"],
+) => {
+  const postsWithoutL1 = await prisma.post.findMany({
+    select: { txId: true },
+    where: { arweaveL1TxId: null },
+    take: 100,
+  });
+
+  const revisionsWithoutL1 = await prisma.postRevision.findMany({
+    select: { txId: true },
+    where: { arweaveL1TxId: null },
+    take: 100,
+  });
+
+  const txIdsSet = new Set<string>();
+  for (const p of postsWithoutL1) {
+    txIdsSet.add(p.txId);
+  }
+  for (const r of revisionsWithoutL1) {
+    txIdsSet.add(r.txId);
+  }
+
+  const txIds = Array.from(txIdsSet).slice(0, 100);
+
+  if (txIds.length === 0) {
+    consola.debug("No posts or revisions missing arweaveL1TxId found");
+    return;
+  }
+
+  consola.info("Syncing arweaveL1TxId for transaction IDs", {
+    count: txIds.length,
+  });
+
+  const fetchResult = await fetchArweaveL1TxIds(txIds);
+  if (fetchResult.isErr()) {
+    consola.error("Failed to fetch L1 tx IDs from Arweave GraphQL", {
+      error: fetchResult.error,
+    });
+    throw new Error(fetchResult.error.error);
+  }
+
+  const mapping = fetchResult.value;
+  const updatedTxIds = Object.keys(mapping);
+
+  if (updatedTxIds.length === 0) {
+    consola.info("No new L1 transaction IDs found on Arweave yet");
+    return;
+  }
+
+  let updatedPostsCount = 0;
+  let updatedRevisionsCount = 0;
+
+  for (const [txId, arweaveL1TxId] of Object.entries(mapping)) {
+    const postRes = await prisma.post.updateMany({
+      where: { txId, arweaveL1TxId: null },
+      data: { arweaveL1TxId },
+    });
+    updatedPostsCount += postRes.count;
+
+    const revRes = await prisma.postRevision.updateMany({
+      where: { txId, arweaveL1TxId: null },
+      data: { arweaveL1TxId },
+    });
+    updatedRevisionsCount += revRes.count;
+  }
+
+  consola.info("Finished syncing arweaveL1TxId", {
+    checked: txIds.length,
+    foundL1TxIds: updatedTxIds.length,
+    updatedPosts: updatedPostsCount,
+    updatedRevisions: updatedRevisionsCount,
+  });
+};

--- a/apps/server/src/plugins/jobs.ts
+++ b/apps/server/src/plugins/jobs.ts
@@ -12,6 +12,11 @@ export default definePlugin(async () => {
     .register(generateImageBlurhashJob);
   await jobs.start();
 
+  await boss.schedule("indexer", "0 * * * *", {
+    action: "indexer-sync-arweave-l1-tx-ids",
+    data: {},
+  });
+
   // await indexerJob.emit({
   //   action: "indexer-index-posts",
   //   data: {},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of Arweave L1 transaction IDs for posts and revisions.
  * The indexer now runs this synchronization job hourly.
  * Supports batched transaction lookups and updates records missing L1 IDs.

* **Bug Fixes**
  * Handles unavailable transaction mappings and Arweave API request failures gracefully.
  * Skips unnecessary processing when no records require synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->